### PR TITLE
feat: support key prefixes and special keys

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -66,7 +66,7 @@ module.exports = grammar({
       seq('"', /[^"]*/, '"'),
       seq("'", /[^']*/, "'"),
     ),
-    color_value: $ => token(prec(1,hex_color)),
+    color_value: $ => hex_color,
     // Expressed as separate regexes to avoid lexical precedence issues with `raw_value`
     percent_adjustment: $ => percent_assignment,
     //percent_adjustment: $ => seq(number, token.immediate("%")),
@@ -130,8 +130,7 @@ module.exports = grammar({
     ),
 
     // Prefix for a single key
-    key_prefix: $ => "physical",
-
+    key_prefix: $ => seq(field("prefix_name", "physical"), token.immediate(":")),
     // The keybind themselves. Ghostty supports stringing chords together.
     keybind_trigger: $ => sep1($.chord, ">"),
 
@@ -148,13 +147,8 @@ module.exports = grammar({
 
     // Non-modifier keys
     key: $ => seq(
-      optional(
-        seq(
-          $.key_prefix,
-          token.immediate(":"),
-        )
-      ),
-      field("bind", $._snake_case_identifier),
+      optional($.key_prefix),
+      field("bind", choice($._snake_case_identifier, /[^>=:]{1}/)),
     ),
 
     // The action to be taken when the keybind is triggered

--- a/grammar.js
+++ b/grammar.js
@@ -109,7 +109,7 @@ module.exports = grammar({
       field("value", $._keybind_value),
       newline,
     ),
-    _keybind_value: $ => choice($.keybind_value, alias("clear", $.value), alias($.string_literal, $.value)),
+    _keybind_value: $ => choice($.keybind_value, alias("clear", $.keybind_clear_keyword), alias($.string_literal, $.value)),
 
     // The overall syntax for keybind values
     keybind_value: $ => seq(

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -25,4 +25,4 @@
 
 (palette_value [(color_value) (palette_index)] @markup.italic @markup.bold)
 
-(config_file_directive (raw_value) @string.special.path)
+(config_file_directive (path_value) @string.special.path)

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -224,15 +224,8 @@
       ]
     },
     "color_value": {
-      "type": "TOKEN",
-      "content": {
-        "type": "PREC",
-        "value": 1,
-        "content": {
-          "type": "PATTERN",
-          "value": "#?[0-9a-fA-F]{6}"
-        }
-      }
+      "type": "PATTERN",
+      "value": "#?[0-9a-fA-F]{6}"
     },
     "percent_adjustment": {
       "type": "PATTERN",
@@ -501,8 +494,24 @@
       ]
     },
     "key_prefix": {
-      "type": "STRING",
-      "value": "physical"
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "prefix_name",
+          "content": {
+            "type": "STRING",
+            "value": "physical"
+          }
+        },
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "STRING",
+            "value": ":"
+          }
+        }
+      ]
     },
     "keybind_trigger": {
       "type": "SEQ",
@@ -620,20 +629,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "key_prefix"
-                },
-                {
-                  "type": "IMMEDIATE_TOKEN",
-                  "content": {
-                    "type": "STRING",
-                    "value": ":"
-                  }
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "key_prefix"
             },
             {
               "type": "BLANK"
@@ -644,8 +641,17 @@
           "type": "FIELD",
           "name": "bind",
           "content": {
-            "type": "SYMBOL",
-            "name": "_snake_case_identifier"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_snake_case_identifier"
+              },
+              {
+                "type": "PATTERN",
+                "value": "[^>=:]{1}"
+              }
+            ]
           }
         }
       ]

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -108,9 +108,22 @@
         }
       ]
     },
-    "property": {
+    "_kebab_case_identifier": {
       "type": "PATTERN",
       "value": "[a-z]+(-[a-z]+)*"
+    },
+    "_snake_case_identifier": {
+      "type": "PATTERN",
+      "value": "[a-z\\_]+\\d*"
+    },
+    "property": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_kebab_case_identifier"
+        }
+      ]
     },
     "value": {
       "type": "CHOICE",
@@ -118,10 +131,6 @@
         {
           "type": "SYMBOL",
           "name": "boolean_literal"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "string_literal"
         },
         {
           "type": "SYMBOL",
@@ -134,6 +143,10 @@
         {
           "type": "SYMBOL",
           "name": "color_value"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "string_literal"
         },
         {
           "type": "SYMBOL",
@@ -170,18 +183,6 @@
           "name": "numeric_adjustment"
         }
       ]
-    },
-    "color_value": {
-      "type": "PATTERN",
-      "value": "#?[0-9a-fA-F]{6}"
-    },
-    "percent_adjustment": {
-      "type": "PATTERN",
-      "value": "[+-]?[0-9]+(\\.[0-9]+)?%"
-    },
-    "numeric_adjustment": {
-      "type": "PATTERN",
-      "value": "[+-][0-9]+(\\.[0-9]+)?"
     },
     "string_literal": {
       "type": "CHOICE",
@@ -222,13 +223,28 @@
         }
       ]
     },
-    "raw_value": {
-      "type": "PREC",
-      "value": -1,
+    "color_value": {
+      "type": "TOKEN",
       "content": {
-        "type": "PATTERN",
-        "value": "[^\\r\\n]+"
+        "type": "PREC",
+        "value": 1,
+        "content": {
+          "type": "PATTERN",
+          "value": "#?[0-9a-fA-F]{6}"
+        }
       }
+    },
+    "percent_adjustment": {
+      "type": "PATTERN",
+      "value": "[+-]?[0-9]+(\\.[0-9]+)?%"
+    },
+    "numeric_adjustment": {
+      "type": "PATTERN",
+      "value": "[+-][0-9]+(\\.[0-9]+)?"
+    },
+    "raw_value": {
+      "type": "PATTERN",
+      "value": "[^\\r\\n]+"
     },
     "palette_directive": {
       "type": "SEQ",
@@ -330,7 +346,7 @@
           "name": "value",
           "content": {
             "type": "SYMBOL",
-            "name": "raw_value"
+            "name": "path_value"
           }
         },
         {
@@ -378,8 +394,31 @@
       ]
     },
     "_keybind_value": {
-      "type": "SYMBOL",
-      "name": "keybind_value"
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "keybind_value"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "clear"
+          },
+          "named": true,
+          "value": "value"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "string_literal"
+          },
+          "named": true,
+          "value": "value"
+        }
+      ]
     },
     "keybind_value": {
       "type": "SEQ",
@@ -460,6 +499,10 @@
           }
         }
       ]
+    },
+    "key_prefix": {
+      "type": "STRING",
+      "value": "physical"
     },
     "keybind_trigger": {
       "type": "SEQ",
@@ -571,8 +614,41 @@
       ]
     },
     "key": {
-      "type": "PATTERN",
-      "value": "[^>=:]{1}"
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "key_prefix"
+                },
+                {
+                  "type": "IMMEDIATE_TOKEN",
+                  "content": {
+                    "type": "STRING",
+                    "value": ":"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "FIELD",
+          "name": "bind",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_snake_case_identifier"
+          }
+        }
+      ]
     },
     "keybind_action": {
       "type": "SEQ",
@@ -583,8 +659,8 @@
           "content": {
             "type": "ALIAS",
             "content": {
-              "type": "PATTERN",
-              "value": "[a-z\\_]+"
+              "type": "SYMBOL",
+              "name": "_snake_case_identifier"
             },
             "named": true,
             "value": "action_name"

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -147,6 +147,22 @@
     "fields": {}
   },
   {
+    "type": "key_prefix",
+    "named": true,
+    "fields": {
+      "prefix_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "physical",
+            "named": false
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "keybind_action",
     "named": true,
     "fields": {
@@ -470,10 +486,6 @@
     "named": false
   },
   {
-    "type": "key_prefix",
-    "named": true
-  },
-  {
     "type": "local",
     "named": false
   },
@@ -500,6 +512,10 @@
   {
     "type": "percent_adjustment",
     "named": true
+  },
+  {
+    "type": "physical",
+    "named": false
   },
   {
     "type": "shift",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -92,7 +92,7 @@
         "required": true,
         "types": [
           {
-            "type": "raw_value",
+            "type": "path_value",
             "named": true
           }
         ]
@@ -121,6 +121,21 @@
         },
         {
           "type": "palette_directive",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "key",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "key_prefix",
           "named": true
         }
       ]
@@ -177,6 +192,10 @@
         "types": [
           {
             "type": "keybind_value",
+            "named": true
+          },
+          {
+            "type": "value",
             "named": true
           }
         ]
@@ -308,6 +327,16 @@
     }
   },
   {
+    "type": "path_value",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "property",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "raw_value",
     "named": true,
     "fields": {}
@@ -343,7 +372,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "adjustment",
@@ -441,7 +470,7 @@
     "named": false
   },
   {
-    "type": "key",
+    "type": "key_prefix",
     "named": true
   },
   {
@@ -470,10 +499,6 @@
   },
   {
     "type": "percent_adjustment",
-    "named": true
-  },
-  {
-    "type": "property",
     "named": true
   },
   {

--- a/src/parser.c
+++ b/src/parser.c
@@ -5,80 +5,85 @@
 #endif
 
 #define LANGUAGE_VERSION 14
-#define STATE_COUNT 60
+#define STATE_COUNT 67
 #define LARGE_STATE_COUNT 2
-#define SYMBOL_COUNT 63
-#define ALIAS_COUNT 1
-#define TOKEN_COUNT 40
+#define SYMBOL_COUNT 67
+#define ALIAS_COUNT 2
+#define TOKEN_COUNT 41
 #define EXTERNAL_TOKEN_COUNT 0
-#define FIELD_COUNT 7
+#define FIELD_COUNT 8
 #define MAX_ALIAS_SEQUENCE_LENGTH 4
-#define PRODUCTION_ID_COUNT 8
+#define PRODUCTION_ID_COUNT 11
 
 enum ts_symbol_identifiers {
   aux_sym_source_file_token1 = 1,
   sym_comment = 2,
   anon_sym_EQ = 3,
-  sym_property = 4,
-  anon_sym_true = 5,
-  anon_sym_false = 6,
-  sym_number_literal = 7,
-  sym_color_value = 8,
-  sym_percent_adjustment = 9,
-  sym_numeric_adjustment = 10,
-  anon_sym_DQUOTE = 11,
-  aux_sym_string_literal_token1 = 12,
-  anon_sym_SQUOTE = 13,
-  aux_sym_string_literal_token2 = 14,
-  aux_sym_raw_value_token1 = 15,
-  anon_sym_palette = 16,
-  aux_sym_palette_value_token1 = 17,
-  anon_sym_EQ2 = 18,
-  aux_sym_palette_value_token2 = 19,
-  anon_sym_config_DASHfile = 20,
-  anon_sym_keybind = 21,
-  anon_sym_all = 22,
-  anon_sym_global = 23,
-  anon_sym_local = 24,
-  anon_sym_unconsumed = 25,
-  anon_sym_COLON = 26,
-  anon_sym_GT = 27,
-  anon_sym_PLUS = 28,
-  anon_sym_shift = 29,
-  anon_sym_ctrl = 30,
-  anon_sym_control = 31,
-  anon_sym_alt = 32,
-  anon_sym_option = 33,
-  anon_sym_opt = 34,
-  anon_sym_super = 35,
-  anon_sym_cmd = 36,
-  anon_sym_command = 37,
-  sym_key = 38,
-  aux_sym_keybind_action_token1 = 39,
-  sym_source_file = 40,
-  sym_directive = 41,
-  sym_basic_directive = 42,
-  sym_value = 43,
-  sym_boolean_literal = 44,
-  sym_adjustment = 45,
-  sym_string_literal = 46,
-  sym_raw_value = 47,
-  sym_palette_directive = 48,
-  sym_palette_value = 49,
-  sym_config_file_directive = 50,
-  sym_keybind_directive = 51,
-  sym__keybind_value = 52,
-  sym_keybind_value = 53,
-  sym_keybind_modifier = 54,
-  sym_keybind_trigger = 55,
-  sym_chord = 56,
-  sym_key_modifier = 57,
-  sym_keybind_action = 58,
-  aux_sym_source_file_repeat1 = 59,
-  aux_sym_keybind_value_repeat1 = 60,
-  aux_sym_keybind_trigger_repeat1 = 61,
-  aux_sym_chord_repeat1 = 62,
-  alias_sym_action_argument = 63,
+  sym__kebab_case_identifier = 4,
+  sym__snake_case_identifier = 5,
+  anon_sym_true = 6,
+  anon_sym_false = 7,
+  sym_number_literal = 8,
+  anon_sym_DQUOTE = 9,
+  aux_sym_string_literal_token1 = 10,
+  anon_sym_SQUOTE = 11,
+  aux_sym_string_literal_token2 = 12,
+  sym_color_value = 13,
+  sym_percent_adjustment = 14,
+  sym_numeric_adjustment = 15,
+  aux_sym_raw_value_token1 = 16,
+  anon_sym_palette = 17,
+  aux_sym_palette_value_token1 = 18,
+  anon_sym_EQ2 = 19,
+  aux_sym_palette_value_token2 = 20,
+  anon_sym_config_DASHfile = 21,
+  anon_sym_keybind = 22,
+  anon_sym_clear = 23,
+  anon_sym_all = 24,
+  anon_sym_global = 25,
+  anon_sym_local = 26,
+  anon_sym_unconsumed = 27,
+  anon_sym_COLON = 28,
+  sym_key_prefix = 29,
+  anon_sym_GT = 30,
+  anon_sym_PLUS = 31,
+  anon_sym_shift = 32,
+  anon_sym_ctrl = 33,
+  anon_sym_control = 34,
+  anon_sym_alt = 35,
+  anon_sym_option = 36,
+  anon_sym_opt = 37,
+  anon_sym_super = 38,
+  anon_sym_cmd = 39,
+  anon_sym_command = 40,
+  sym_source_file = 41,
+  sym_directive = 42,
+  sym_basic_directive = 43,
+  sym_property = 44,
+  sym_value = 45,
+  sym_boolean_literal = 46,
+  sym_adjustment = 47,
+  sym_string_literal = 48,
+  sym_raw_value = 49,
+  sym_palette_directive = 50,
+  sym_palette_value = 51,
+  sym_config_file_directive = 52,
+  sym_path_value = 53,
+  sym_keybind_directive = 54,
+  sym__keybind_value = 55,
+  sym_keybind_value = 56,
+  sym_keybind_modifier = 57,
+  sym_keybind_trigger = 58,
+  sym_chord = 59,
+  sym_key_modifier = 60,
+  sym_key = 61,
+  sym_keybind_action = 62,
+  aux_sym_source_file_repeat1 = 63,
+  aux_sym_keybind_value_repeat1 = 64,
+  aux_sym_keybind_trigger_repeat1 = 65,
+  aux_sym_chord_repeat1 = 66,
+  alias_sym_action_argument = 67,
+  alias_sym_action_name = 68,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -86,17 +91,18 @@ static const char * const ts_symbol_names[] = {
   [aux_sym_source_file_token1] = "source_file_token1",
   [sym_comment] = "comment",
   [anon_sym_EQ] = "=",
-  [sym_property] = "property",
+  [sym__kebab_case_identifier] = "_kebab_case_identifier",
+  [sym__snake_case_identifier] = "_snake_case_identifier",
   [anon_sym_true] = "true",
   [anon_sym_false] = "false",
   [sym_number_literal] = "number_literal",
-  [sym_color_value] = "color_value",
-  [sym_percent_adjustment] = "percent_adjustment",
-  [sym_numeric_adjustment] = "numeric_adjustment",
   [anon_sym_DQUOTE] = "\"",
   [aux_sym_string_literal_token1] = "string_literal_token1",
   [anon_sym_SQUOTE] = "'",
   [aux_sym_string_literal_token2] = "string_literal_token2",
+  [sym_color_value] = "color_value",
+  [sym_percent_adjustment] = "percent_adjustment",
+  [sym_numeric_adjustment] = "numeric_adjustment",
   [aux_sym_raw_value_token1] = "raw_value_token1",
   [anon_sym_palette] = "property",
   [aux_sym_palette_value_token1] = "palette_index",
@@ -104,11 +110,13 @@ static const char * const ts_symbol_names[] = {
   [aux_sym_palette_value_token2] = "color_value",
   [anon_sym_config_DASHfile] = "property",
   [anon_sym_keybind] = "property",
+  [anon_sym_clear] = "value",
   [anon_sym_all] = "all",
   [anon_sym_global] = "global",
   [anon_sym_local] = "local",
   [anon_sym_unconsumed] = "unconsumed",
   [anon_sym_COLON] = ":",
+  [sym_key_prefix] = "key_prefix",
   [anon_sym_GT] = ">",
   [anon_sym_PLUS] = "+",
   [anon_sym_shift] = "shift",
@@ -120,11 +128,10 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_super] = "super",
   [anon_sym_cmd] = "cmd",
   [anon_sym_command] = "command",
-  [sym_key] = "key",
-  [aux_sym_keybind_action_token1] = "action_name",
   [sym_source_file] = "source_file",
   [sym_directive] = "directive",
   [sym_basic_directive] = "basic_directive",
+  [sym_property] = "property",
   [sym_value] = "value",
   [sym_boolean_literal] = "boolean_literal",
   [sym_adjustment] = "adjustment",
@@ -133,6 +140,7 @@ static const char * const ts_symbol_names[] = {
   [sym_palette_directive] = "palette_directive",
   [sym_palette_value] = "palette_value",
   [sym_config_file_directive] = "config_file_directive",
+  [sym_path_value] = "path_value",
   [sym_keybind_directive] = "keybind_directive",
   [sym__keybind_value] = "_keybind_value",
   [sym_keybind_value] = "keybind_value",
@@ -140,12 +148,14 @@ static const char * const ts_symbol_names[] = {
   [sym_keybind_trigger] = "keybind_trigger",
   [sym_chord] = "chord",
   [sym_key_modifier] = "key_modifier",
+  [sym_key] = "key",
   [sym_keybind_action] = "keybind_action",
   [aux_sym_source_file_repeat1] = "source_file_repeat1",
   [aux_sym_keybind_value_repeat1] = "keybind_value_repeat1",
   [aux_sym_keybind_trigger_repeat1] = "keybind_trigger_repeat1",
   [aux_sym_chord_repeat1] = "chord_repeat1",
   [alias_sym_action_argument] = "action_argument",
+  [alias_sym_action_name] = "action_name",
 };
 
 static const TSSymbol ts_symbol_map[] = {
@@ -153,17 +163,18 @@ static const TSSymbol ts_symbol_map[] = {
   [aux_sym_source_file_token1] = aux_sym_source_file_token1,
   [sym_comment] = sym_comment,
   [anon_sym_EQ] = anon_sym_EQ,
-  [sym_property] = sym_property,
+  [sym__kebab_case_identifier] = sym__kebab_case_identifier,
+  [sym__snake_case_identifier] = sym__snake_case_identifier,
   [anon_sym_true] = anon_sym_true,
   [anon_sym_false] = anon_sym_false,
   [sym_number_literal] = sym_number_literal,
-  [sym_color_value] = sym_color_value,
-  [sym_percent_adjustment] = sym_percent_adjustment,
-  [sym_numeric_adjustment] = sym_numeric_adjustment,
   [anon_sym_DQUOTE] = anon_sym_DQUOTE,
   [aux_sym_string_literal_token1] = aux_sym_string_literal_token1,
   [anon_sym_SQUOTE] = anon_sym_SQUOTE,
   [aux_sym_string_literal_token2] = aux_sym_string_literal_token2,
+  [sym_color_value] = sym_color_value,
+  [sym_percent_adjustment] = sym_percent_adjustment,
+  [sym_numeric_adjustment] = sym_numeric_adjustment,
   [aux_sym_raw_value_token1] = aux_sym_raw_value_token1,
   [anon_sym_palette] = sym_property,
   [aux_sym_palette_value_token1] = aux_sym_palette_value_token1,
@@ -171,11 +182,13 @@ static const TSSymbol ts_symbol_map[] = {
   [aux_sym_palette_value_token2] = sym_color_value,
   [anon_sym_config_DASHfile] = sym_property,
   [anon_sym_keybind] = sym_property,
+  [anon_sym_clear] = sym_value,
   [anon_sym_all] = anon_sym_all,
   [anon_sym_global] = anon_sym_global,
   [anon_sym_local] = anon_sym_local,
   [anon_sym_unconsumed] = anon_sym_unconsumed,
   [anon_sym_COLON] = anon_sym_COLON,
+  [sym_key_prefix] = sym_key_prefix,
   [anon_sym_GT] = anon_sym_GT,
   [anon_sym_PLUS] = anon_sym_PLUS,
   [anon_sym_shift] = anon_sym_shift,
@@ -187,11 +200,10 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_super] = anon_sym_super,
   [anon_sym_cmd] = anon_sym_cmd,
   [anon_sym_command] = anon_sym_command,
-  [sym_key] = sym_key,
-  [aux_sym_keybind_action_token1] = aux_sym_keybind_action_token1,
   [sym_source_file] = sym_source_file,
   [sym_directive] = sym_directive,
   [sym_basic_directive] = sym_basic_directive,
+  [sym_property] = sym_property,
   [sym_value] = sym_value,
   [sym_boolean_literal] = sym_boolean_literal,
   [sym_adjustment] = sym_adjustment,
@@ -200,6 +212,7 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_palette_directive] = sym_palette_directive,
   [sym_palette_value] = sym_palette_value,
   [sym_config_file_directive] = sym_config_file_directive,
+  [sym_path_value] = sym_path_value,
   [sym_keybind_directive] = sym_keybind_directive,
   [sym__keybind_value] = sym__keybind_value,
   [sym_keybind_value] = sym_keybind_value,
@@ -207,12 +220,14 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_keybind_trigger] = sym_keybind_trigger,
   [sym_chord] = sym_chord,
   [sym_key_modifier] = sym_key_modifier,
+  [sym_key] = sym_key,
   [sym_keybind_action] = sym_keybind_action,
   [aux_sym_source_file_repeat1] = aux_sym_source_file_repeat1,
   [aux_sym_keybind_value_repeat1] = aux_sym_keybind_value_repeat1,
   [aux_sym_keybind_trigger_repeat1] = aux_sym_keybind_trigger_repeat1,
   [aux_sym_chord_repeat1] = aux_sym_chord_repeat1,
   [alias_sym_action_argument] = alias_sym_action_argument,
+  [alias_sym_action_name] = alias_sym_action_name,
 };
 
 static const TSSymbolMetadata ts_symbol_metadata[] = {
@@ -232,8 +247,12 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
-  [sym_property] = {
-    .visible = true,
+  [sym__kebab_case_identifier] = {
+    .visible = false,
+    .named = true,
+  },
+  [sym__snake_case_identifier] = {
+    .visible = false,
     .named = true,
   },
   [anon_sym_true] = {
@@ -245,18 +264,6 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = false,
   },
   [sym_number_literal] = {
-    .visible = true,
-    .named = true,
-  },
-  [sym_color_value] = {
-    .visible = true,
-    .named = true,
-  },
-  [sym_percent_adjustment] = {
-    .visible = true,
-    .named = true,
-  },
-  [sym_numeric_adjustment] = {
     .visible = true,
     .named = true,
   },
@@ -275,6 +282,18 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
   [aux_sym_string_literal_token2] = {
     .visible = false,
     .named = false,
+  },
+  [sym_color_value] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_percent_adjustment] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_numeric_adjustment] = {
+    .visible = true,
+    .named = true,
   },
   [aux_sym_raw_value_token1] = {
     .visible = false,
@@ -304,6 +323,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
+  [anon_sym_clear] = {
+    .visible = true,
+    .named = true,
+  },
   [anon_sym_all] = {
     .visible = true,
     .named = false,
@@ -323,6 +346,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
   [anon_sym_COLON] = {
     .visible = true,
     .named = false,
+  },
+  [sym_key_prefix] = {
+    .visible = true,
+    .named = true,
   },
   [anon_sym_GT] = {
     .visible = true,
@@ -368,14 +395,6 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
-  [sym_key] = {
-    .visible = true,
-    .named = true,
-  },
-  [aux_sym_keybind_action_token1] = {
-    .visible = true,
-    .named = true,
-  },
   [sym_source_file] = {
     .visible = true,
     .named = true,
@@ -385,6 +404,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = true,
   },
   [sym_basic_directive] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_property] = {
     .visible = true,
     .named = true,
   },
@@ -420,6 +443,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
+  [sym_path_value] = {
+    .visible = true,
+    .named = true,
+  },
   [sym_keybind_directive] = {
     .visible = true,
     .named = true,
@@ -448,6 +475,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
+  [sym_key] = {
+    .visible = true,
+    .named = true,
+  },
   [sym_keybind_action] = {
     .visible = true,
     .named = true,
@@ -472,16 +503,21 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
+  [alias_sym_action_name] = {
+    .visible = true,
+    .named = true,
+  },
 };
 
 enum ts_field_identifiers {
   field_action = 1,
   field_action_name = 2,
   field_argument = 3,
-  field_modifier = 4,
-  field_property = 5,
-  field_trigger = 6,
-  field_value = 7,
+  field_bind = 4,
+  field_modifier = 5,
+  field_property = 6,
+  field_trigger = 7,
+  field_value = 8,
 };
 
 static const char * const ts_field_names[] = {
@@ -489,6 +525,7 @@ static const char * const ts_field_names[] = {
   [field_action] = "action",
   [field_action_name] = "action_name",
   [field_argument] = "argument",
+  [field_bind] = "bind",
   [field_modifier] = "modifier",
   [field_property] = "property",
   [field_trigger] = "trigger",
@@ -497,43 +534,59 @@ static const char * const ts_field_names[] = {
 
 static const TSFieldMapSlice ts_field_map_slices[PRODUCTION_ID_COUNT] = {
   [1] = {.index = 0, .length = 1},
-  [2] = {.index = 1, .length = 2},
-  [3] = {.index = 3, .length = 1},
-  [4] = {.index = 4, .length = 1},
-  [5] = {.index = 5, .length = 2},
-  [6] = {.index = 7, .length = 2},
-  [7] = {.index = 9, .length = 2},
+  [2] = {.index = 1, .length = 1},
+  [4] = {.index = 2, .length = 2},
+  [5] = {.index = 4, .length = 1},
+  [6] = {.index = 5, .length = 1},
+  [7] = {.index = 6, .length = 1},
+  [8] = {.index = 7, .length = 2},
+  [9] = {.index = 9, .length = 2},
+  [10] = {.index = 11, .length = 2},
 };
 
 static const TSFieldMapEntry ts_field_map_entries[] = {
   [0] =
     {field_property, 0},
   [1] =
+    {field_bind, 0},
+  [2] =
     {field_property, 0},
     {field_value, 2},
-  [3] =
-    {field_modifier, 0},
   [4] =
-    {field_action_name, 0},
+    {field_modifier, 0},
   [5] =
+    {field_bind, 2},
+  [6] =
+    {field_action_name, 0},
+  [7] =
     {field_action, 2},
     {field_trigger, 0},
-  [7] =
+  [9] =
     {field_action, 3},
     {field_trigger, 1},
-  [9] =
+  [11] =
     {field_action_name, 0},
     {field_argument, 2},
 };
 
 static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
   [0] = {0},
+  [3] = {
+    [0] = sym_value,
+  },
   [7] = {
+    [0] = alias_sym_action_name,
+  },
+  [10] = {
+    [0] = alias_sym_action_name,
     [2] = alias_sym_action_argument,
   },
 };
 
 static const uint16_t ts_non_terminal_alias_map[] = {
+  sym_string_literal, 2,
+    sym_string_literal,
+    sym_value,
   sym_raw_value, 2,
     sym_raw_value,
     alias_sym_action_argument,
@@ -601,6 +654,13 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [57] = 57,
   [58] = 58,
   [59] = 59,
+  [60] = 60,
+  [61] = 61,
+  [62] = 62,
+  [63] = 63,
+  [64] = 64,
+  [65] = 65,
+  [66] = 66,
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -608,1796 +668,2207 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(66);
+      if (eof) ADVANCE(32);
       ADVANCE_MAP(
-        '"', 202,
-        '#', 60,
-        '\'', 206,
-        '+', 251,
-        ':', 249,
-        '=', 234,
-        '>', 250,
-        '_', 279,
-        'a', 99,
-        'c', 110,
-        'f', 71,
-        'g', 109,
-        'k', 85,
-        'l', 120,
-        'o', 125,
-        'p', 72,
-        's', 95,
-        't', 127,
-        'u', 117,
-        'b', 148,
-        'd', 148,
-        'e', 148,
+        '"', 219,
+        '#', 26,
+        '\'', 223,
+        '+', 278,
+        '-', 13,
+        ':', 273,
+        '=', 258,
+        '>', 276,
+        '_', 198,
+        'a', 69,
+        'c', 77,
+        'f', 37,
+        'g', 78,
+        'k', 53,
+        'l', 88,
+        'o', 93,
+        'p', 38,
+        's', 64,
+        't', 95,
+        'u', 85,
+        'b', 115,
+        'd', 115,
+        'e', 115,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(65);
-      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(58);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(194);
-      if (('h' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+          lookahead == ' ') SKIP(31);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(24);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(211);
+      if (('h' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 1:
-      if (lookahead == '\n') ADVANCE(67);
+      if (lookahead == '\n') ADVANCE(33);
       if (lookahead == '\r') ADVANCE(1);
       if (lookahead == '#') ADVANCE(3);
-      if (lookahead == 'c') ADVANCE(167);
-      if (lookahead == 'k') ADVANCE(155);
-      if (lookahead == 'p') ADVANCE(151);
+      if (lookahead == 'c') ADVANCE(133);
+      if (lookahead == 'k') ADVANCE(121);
+      if (lookahead == 'p') ADVANCE(117);
       if (('\t' <= lookahead && lookahead <= '\f') ||
           lookahead == ' ') SKIP(1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(233);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(171);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(257);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 2:
-      if (lookahead == '\n') ADVANCE(69);
+      if (lookahead == '\n') ADVANCE(35);
       END_STATE();
     case 3:
-      if (lookahead == '\n') ADVANCE(69);
+      if (lookahead == '\n') ADVANCE(35);
       if (lookahead == '\r') ADVANCE(2);
       if (lookahead != 0) ADVANCE(3);
       END_STATE();
     case 4:
       ADVANCE_MAP(
-        '\n', 68,
+        '\n', 34,
         '\r', 4,
-        '"', 203,
-        '#', 227,
-        '\'', 207,
-        'f', 211,
-        't', 215,
-        '+', 219,
-        '-', 219,
-        '\t', 210,
-        0x0b, 210,
-        '\f', 210,
-        ' ', 210,
+        '"', 220,
+        '#', 251,
+        '\'', 224,
+        'f', 235,
+        't', 239,
+        '+', 243,
+        '-', 243,
+        '\t', 234,
+        0x0b, 234,
+        '\f', 234,
+        ' ', 234,
       );
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(183);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(217);
       if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'e')) ADVANCE(226);
-      if (lookahead != 0) ADVANCE(228);
+          ('a' <= lookahead && lookahead <= 'e')) ADVANCE(250);
+      if (lookahead != 0) ADVANCE(252);
       END_STATE();
     case 5:
-      if (lookahead == '#') ADVANCE(60);
-      if (lookahead == '=') ADVANCE(70);
+      ADVANCE_MAP(
+        '"', 219,
+        '\'', 223,
+        '+', 277,
+        '=', 258,
+        '>', 276,
+        'a', 160,
+        'c', 161,
+        'g', 168,
+        'l', 178,
+        'o', 183,
+        'p', 156,
+        's', 157,
+        'u', 176,
+      );
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(8);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(58);
+          lookahead == ' ') SKIP(6);
+      if (lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 6:
-      if (lookahead == '+') ADVANCE(251);
-      if (lookahead == '=') ADVANCE(234);
-      if (lookahead == '>') ADVANCE(250);
+      ADVANCE_MAP(
+        '"', 219,
+        '\'', 223,
+        '+', 277,
+        '>', 276,
+        'a', 160,
+        'c', 161,
+        'g', 168,
+        'l', 178,
+        'o', 183,
+        'p', 156,
+        's', 157,
+        'u', 176,
+      );
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(7);
+          lookahead == ' ') SKIP(6);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(279);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 7:
-      if (lookahead == '+') ADVANCE(251);
-      if (lookahead == '>') ADVANCE(250);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(7);
-      if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(279);
+      if (lookahead == '#') ADVANCE(27);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(25);
       END_STATE();
     case 8:
-      if (lookahead == '=') ADVANCE(70);
+      ADVANCE_MAP(
+        '=', 36,
+        'a', 160,
+        'c', 170,
+        'g', 168,
+        'l', 178,
+        'o', 183,
+        'p', 156,
+        's', 157,
+        'u', 176,
+      );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(8);
+      if (lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 9:
-      if (lookahead == 'a') ADVANCE(273);
-      if (lookahead == 'c') ADVANCE(275);
-      if (lookahead == 'g') ADVANCE(274);
-      if (lookahead == 'l') ADVANCE(277);
-      if (lookahead == 'o') ADVANCE(278);
-      if (lookahead == 's') ADVANCE(272);
-      if (lookahead == 'u') ADVANCE(276);
+      if (lookahead == 'a') ADVANCE(169);
+      if (lookahead == 'c') ADVANCE(170);
+      if (lookahead == 'o') ADVANCE(183);
+      if (lookahead == 'p') ADVANCE(156);
+      if (lookahead == 's') ADVANCE(157);
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(271);
-      if (lookahead != 0 &&
-          lookahead != ':' &&
-          lookahead != '=' &&
-          lookahead != '>') ADVANCE(270);
+          lookahead == ' ') SKIP(9);
+      if (lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 10:
-      if (lookahead == 'a') ADVANCE(26);
+      if (lookahead == 'f') ADVANCE(126);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 11:
-      if (lookahead == 'a') ADVANCE(34);
+      if (lookahead == '\n' ||
+          lookahead == '\r') SKIP(11);
+      if (('\t' <= lookahead && lookahead <= '\f') ||
+          lookahead == ' ') ADVANCE(242);
+      if (lookahead != 0) ADVANCE(252);
       END_STATE();
     case 12:
-      if (lookahead == 'a') ADVANCE(27);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') SKIP(12);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 13:
-      if (lookahead == 'b') ADVANCE(12);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(230);
       END_STATE();
     case 14:
-      if (lookahead == 'c') ADVANCE(10);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(212);
       END_STATE();
     case 15:
-      if (lookahead == 'c') ADVANCE(36);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(231);
       END_STATE();
     case 16:
-      if (lookahead == 'd') ADVANCE(266);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(227);
       END_STATE();
     case 17:
-      if (lookahead == 'd') ADVANCE(268);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(259);
       END_STATE();
     case 18:
-      if (lookahead == 'd') ADVANCE(247);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(16);
       END_STATE();
     case 19:
-      if (lookahead == 'e') ADVANCE(18);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(17);
       END_STATE();
     case 20:
-      if (lookahead == 'e') ADVANCE(41);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(18);
       END_STATE();
     case 21:
-      if (lookahead == 'f') ADVANCE(160);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(171);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(19);
       END_STATE();
     case 22:
-      if (lookahead == 'f') ADVANCE(45);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(20);
       END_STATE();
     case 23:
-      if (lookahead == 'i') ADVANCE(22);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(21);
       END_STATE();
     case 24:
-      if (lookahead == 'l') ADVANCE(241);
-      if (lookahead == 't') ADVANCE(258);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(22);
       END_STATE();
     case 25:
-      if (lookahead == 'l') ADVANCE(254);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(23);
       END_STATE();
     case 26:
-      if (lookahead == 'l') ADVANCE(245);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(24);
       END_STATE();
     case 27:
-      if (lookahead == 'l') ADVANCE(243);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(25);
       END_STATE();
     case 28:
-      if (lookahead == 'l') ADVANCE(256);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 29:
-      if (lookahead == 'm') ADVANCE(30);
-      if (lookahead == 'n') ADVANCE(46);
-      END_STATE();
-    case 30:
-      if (lookahead == 'm') ADVANCE(11);
-      END_STATE();
-    case 31:
-      if (lookahead == 'm') ADVANCE(19);
-      END_STATE();
-    case 32:
-      if (lookahead == 'n') ADVANCE(43);
-      END_STATE();
-    case 33:
-      if (lookahead == 'n') ADVANCE(260);
-      END_STATE();
-    case 34:
-      if (lookahead == 'n') ADVANCE(17);
-      END_STATE();
-    case 35:
-      if (lookahead == 'o') ADVANCE(13);
-      END_STATE();
-    case 36:
-      if (lookahead == 'o') ADVANCE(32);
-      END_STATE();
-    case 37:
-      if (lookahead == 'o') ADVANCE(33);
-      END_STATE();
-    case 38:
-      if (lookahead == 'o') ADVANCE(28);
-      END_STATE();
-    case 39:
-      if (lookahead == 'p') ADVANCE(20);
-      END_STATE();
-    case 40:
-      if (lookahead == 'r') ADVANCE(25);
-      END_STATE();
-    case 41:
-      if (lookahead == 'r') ADVANCE(264);
-      END_STATE();
-    case 42:
-      if (lookahead == 'r') ADVANCE(38);
-      END_STATE();
-    case 43:
-      if (lookahead == 's') ADVANCE(47);
-      END_STATE();
-    case 44:
-      if (lookahead == 't') ADVANCE(263);
-      END_STATE();
-    case 45:
-      if (lookahead == 't') ADVANCE(252);
-      END_STATE();
-    case 46:
-      if (lookahead == 't') ADVANCE(42);
-      END_STATE();
-    case 47:
-      if (lookahead == 'u') ADVANCE(31);
-      END_STATE();
-    case 48:
-      if (lookahead == '\n' ||
-          lookahead == '\r') SKIP(48);
-      if (('\t' <= lookahead && lookahead <= '\f') ||
-          lookahead == ' ') ADVANCE(218);
-      if (lookahead != 0) ADVANCE(228);
-      END_STATE();
-    case 49:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(196);
-      END_STATE();
-    case 50:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(235);
-      END_STATE();
-    case 51:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(197);
-      END_STATE();
-    case 52:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(50);
-      END_STATE();
-    case 53:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(51);
-      END_STATE();
-    case 54:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(52);
-      END_STATE();
-    case 55:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(53);
-      END_STATE();
-    case 56:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(54);
-      END_STATE();
-    case 57:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(55);
-      END_STATE();
-    case 58:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(56);
-      END_STATE();
-    case 59:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(57);
-      END_STATE();
-    case 60:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(58);
-      END_STATE();
-    case 61:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(59);
-      END_STATE();
-    case 62:
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(171);
-      END_STATE();
-    case 63:
-      if (eof) ADVANCE(66);
+      if (eof) ADVANCE(32);
       ADVANCE_MAP(
-        '\n', 67,
+        '\n', 33,
         '\r', 1,
         '#', 3,
-        ':', 249,
-        '=', 234,
-        'c', 167,
-        'k', 155,
-        'p', 151,
+        ':', 273,
+        '=', 258,
+        'c', 133,
+        'k', 121,
+        'p', 117,
       );
       if (('\t' <= lookahead && lookahead <= '\f') ||
-          lookahead == ' ') SKIP(64);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(233);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(171);
+          lookahead == ' ') SKIP(30);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(257);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
-    case 64:
-      if (eof) ADVANCE(66);
-      if (lookahead == '\n') ADVANCE(67);
+    case 30:
+      if (eof) ADVANCE(32);
+      if (lookahead == '\n') ADVANCE(33);
       if (lookahead == '\r') ADVANCE(1);
       if (lookahead == '#') ADVANCE(3);
-      if (lookahead == 'c') ADVANCE(167);
-      if (lookahead == 'k') ADVANCE(155);
-      if (lookahead == 'p') ADVANCE(151);
+      if (lookahead == 'c') ADVANCE(133);
+      if (lookahead == 'k') ADVANCE(121);
+      if (lookahead == 'p') ADVANCE(117);
       if (('\t' <= lookahead && lookahead <= '\f') ||
-          lookahead == ' ') SKIP(64);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(233);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(171);
+          lookahead == ' ') SKIP(30);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(257);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
-    case 65:
-      if (eof) ADVANCE(66);
+    case 31:
+      if (eof) ADVANCE(32);
       ADVANCE_MAP(
-        '"', 202,
-        '#', 61,
-        '\'', 206,
-        '+', 251,
-        '=', 70,
-        '>', 250,
-        '_', 279,
-        'a', 100,
-        'c', 111,
-        'f', 76,
-        'g', 109,
-        'k', 85,
-        'l', 120,
-        'o', 125,
-        'p', 72,
-        's', 95,
-        't', 127,
-        'u', 117,
-        'b', 149,
-        'd', 149,
-        'e', 149,
+        '"', 219,
+        '#', 26,
+        '\'', 223,
+        '+', 278,
+        '-', 13,
+        '=', 36,
+        '>', 276,
+        '_', 198,
+        'a', 69,
+        'c', 77,
+        'f', 37,
+        'g', 78,
+        'k', 53,
+        'l', 88,
+        'o', 93,
+        'p', 38,
+        's', 64,
+        't', 95,
+        'u', 85,
+        'b', 115,
+        'd', 115,
+        'e', 115,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(65);
-      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(59);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(195);
-      if (('h' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+          lookahead == ' ') SKIP(31);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(24);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(211);
+      if (('h' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
-    case 66:
+    case 32:
       ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
-    case 67:
+    case 33:
       ACCEPT_TOKEN(aux_sym_source_file_token1);
-      if (lookahead == '\n') ADVANCE(67);
+      if (lookahead == '\n') ADVANCE(33);
       if (lookahead == '\r') ADVANCE(1);
       END_STATE();
-    case 68:
+    case 34:
       ACCEPT_TOKEN(aux_sym_source_file_token1);
-      if (lookahead == '\n') ADVANCE(68);
+      if (lookahead == '\n') ADVANCE(34);
       if (lookahead == '\r') ADVANCE(4);
+      if (lookahead == '#') ADVANCE(251);
+      if (lookahead == 'f') ADVANCE(235);
       if (('\t' <= lookahead && lookahead <= '\f') ||
-          lookahead == ' ') ADVANCE(210);
+          lookahead == ' ') ADVANCE(234);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(217);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'e')) ADVANCE(250);
       END_STATE();
-    case 69:
+    case 35:
       ACCEPT_TOKEN(sym_comment);
       END_STATE();
-    case 70:
+    case 36:
       ACCEPT_TOKEN(anon_sym_EQ);
       END_STATE();
+    case 37:
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'a') ADVANCE(71);
+      if (('b' <= lookahead && lookahead <= 'f')) ADVANCE(114);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(22);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(202);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 38:
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'a') ADVANCE(79);
+      if (lookahead == 'h') ADVANCE(109);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('b' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 39:
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'a') ADVANCE(96);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('b' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 40:
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'a') ADVANCE(84);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('b' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 41:
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'a') ADVANCE(73);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('b' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 42:
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'a') ADVANCE(74);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('b' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 43:
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'a') ADVANCE(76);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('b' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 44:
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'b') ADVANCE(67);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 45:
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'b') ADVANCE(42);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 46:
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'c') ADVANCE(41);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 47:
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'c') ADVANCE(90);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 48:
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'c') ADVANCE(43);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 49:
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'd') ADVANCE(293);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 50:
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'd') ADVANCE(295);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 51:
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'd') ADVANCE(261);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 52:
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'd') ADVANCE(271);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 53:
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'e') ADVANCE(110);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 54:
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'e') ADVANCE(39);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 55:
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'e') ADVANCE(203);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 56:
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'e') ADVANCE(205);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 57:
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'e') ADVANCE(253);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 58:
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'e') ADVANCE(105);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 59:
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'e') ADVANCE(52);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 60:
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'e') ADVANCE(97);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 61:
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'f') ADVANCE(66);
+      if (lookahead == 't') ADVANCE(99);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 62:
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'f') ADVANCE(104);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 63:
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'g') ADVANCE(138);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 64:
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'h') ADVANCE(65);
+      if (lookahead == 'u') ADVANCE(94);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 65:
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'i') ADVANCE(62);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 66:
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'i') ADVANCE(63);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 67:
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'i') ADVANCE(86);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 68:
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'i') ADVANCE(48);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 69:
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'l') ADVANCE(70);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(22);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(114);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(202);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 70:
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'l') ADVANCE(265);
+      if (lookahead == 't') ADVANCE(285);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
     case 71:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'a') ADVANCE(102);
-      if (('b' <= lookahead && lookahead <= 'f')) ADVANCE(146);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F')) ADVANCE(56);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'l') ADVANCE(102);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(20);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(113);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(200);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 72:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'a') ADVANCE(108);
-      if (('b' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'l') ADVANCE(281);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 73:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'a') ADVANCE(116);
-      if (('b' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'l') ADVANCE(269);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 74:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'a') ADVANCE(105);
-      if (('b' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'l') ADVANCE(267);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 75:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'a') ADVANCE(106);
-      if (('b' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'l') ADVANCE(283);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 76:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'a') ADVANCE(103);
-      if (('b' <= lookahead && lookahead <= 'f')) ADVANCE(147);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F')) ADVANCE(57);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'l') ADVANCE(274);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 77:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'b') ADVANCE(98);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'l') ADVANCE(54);
+      if (lookahead == 'm') ADVANCE(49);
+      if (lookahead == 'o') ADVANCE(80);
+      if (lookahead == 't') ADVANCE(98);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(22);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(114);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(202);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 78:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'b') ADVANCE(75);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'l') ADVANCE(89);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 79:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'c') ADVANCE(122);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'l') ADVANCE(58);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 80:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'c') ADVANCE(74);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'm') ADVANCE(81);
+      if (lookahead == 'n') ADVANCE(61);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 81:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'd') ADVANCE(267);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'm') ADVANCE(40);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 82:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'd') ADVANCE(269);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'm') ADVANCE(59);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 83:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'd') ADVANCE(239);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'n') ADVANCE(287);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 84:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'd') ADVANCE(248);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'n') ADVANCE(50);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 85:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'e') ADVANCE(139);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'n') ADVANCE(47);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 86:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'e') ADVANCE(174);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'n') ADVANCE(51);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 87:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'e') ADVANCE(176);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'n') ADVANCE(100);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 88:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'e') ADVANCE(229);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'o') ADVANCE(46);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 89:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'e') ADVANCE(135);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'o') ADVANCE(45);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 90:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'e') ADVANCE(128);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'o') ADVANCE(87);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 91:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'e') ADVANCE(84);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'o') ADVANCE(83);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 92:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'f') ADVANCE(97);
-      if (lookahead == 't') ADVANCE(130);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'o') ADVANCE(75);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 93:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'f') ADVANCE(134);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'p') ADVANCE(103);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 94:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'g') ADVANCE(172);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'p') ADVANCE(60);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 95:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'h') ADVANCE(96);
-      if (lookahead == 'u') ADVANCE(126);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'r') ADVANCE(108);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 96:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'i') ADVANCE(93);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'r') ADVANCE(263);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 97:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'i') ADVANCE(94);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'r') ADVANCE(291);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 98:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'i') ADVANCE(119);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'r') ADVANCE(72);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 99:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'l') ADVANCE(101);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(146);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F')) ADVANCE(56);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'r') ADVANCE(92);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 100:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'l') ADVANCE(101);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(147);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F')) ADVANCE(57);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 's') ADVANCE(107);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 101:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'l') ADVANCE(242);
-      if (lookahead == 't') ADVANCE(259);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 's') ADVANCE(68);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 102:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'l') ADVANCE(132);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(142);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F')) ADVANCE(54);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 's') ADVANCE(56);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 103:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'l') ADVANCE(132);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(144);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F')) ADVANCE(55);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 't') ADVANCE(289);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 104:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'l') ADVANCE(255);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 't') ADVANCE(279);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 105:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'l') ADVANCE(246);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 't') ADVANCE(106);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 106:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'l') ADVANCE(244);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 't') ADVANCE(57);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 107:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'l') ADVANCE(257);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'u') ADVANCE(82);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 108:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'l') ADVANCE(89);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'u') ADVANCE(55);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 109:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'l') ADVANCE(121);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'y') ADVANCE(101);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 110:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'm') ADVANCE(81);
-      if (lookahead == 'o') ADVANCE(112);
-      if (lookahead == 't') ADVANCE(129);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(146);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F')) ADVANCE(56);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'y') ADVANCE(44);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 111:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'm') ADVANCE(81);
-      if (lookahead == 'o') ADVANCE(112);
-      if (lookahead == 't') ADVANCE(129);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(147);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F')) ADVANCE(57);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(227);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(227);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(227);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 112:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'm') ADVANCE(113);
-      if (lookahead == 'n') ADVANCE(92);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(16);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(111);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(199);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 113:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'm') ADVANCE(73);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(18);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(112);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(201);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 114:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'm') ADVANCE(91);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(20);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(113);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(200);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 115:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'n') ADVANCE(261);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(22);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(114);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(202);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 116:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'n') ADVANCE(82);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 117:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'n') ADVANCE(79);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == 'a') ADVANCE(130);
+      if (('b' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 118:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'n') ADVANCE(131);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == 'b') ADVANCE(128);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 119:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'n') ADVANCE(83);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == 'd') ADVANCE(262);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 120:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'o') ADVANCE(80);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == 'e') ADVANCE(260);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 121:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'o') ADVANCE(78);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == 'e') ADVANCE(136);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 122:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'o') ADVANCE(118);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == 'e') ADVANCE(134);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 123:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'o') ADVANCE(115);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == 'e') ADVANCE(254);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 124:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'o') ADVANCE(107);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == 'f') ADVANCE(127);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 125:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'p') ADVANCE(133);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == 'g') ADVANCE(139);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 126:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'p') ADVANCE(90);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == 'i') ADVANCE(129);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 127:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'r') ADVANCE(138);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == 'i') ADVANCE(125);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 128:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'r') ADVANCE(265);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == 'i') ADVANCE(132);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 129:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'r') ADVANCE(104);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == 'l') ADVANCE(120);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 130:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'r') ADVANCE(124);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == 'l') ADVANCE(122);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 131:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 's') ADVANCE(137);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == 'n') ADVANCE(124);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 132:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 's') ADVANCE(87);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == 'n') ADVANCE(119);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 133:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 't') ADVANCE(262);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == 'o') ADVANCE(131);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 134:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 't') ADVANCE(253);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == 't') ADVANCE(135);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 135:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 't') ADVANCE(136);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == 't') ADVANCE(123);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 136:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 't') ADVANCE(88);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == 'y') ADVANCE(118);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 137:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'u') ADVANCE(114);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 138:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'u') ADVANCE(86);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(10);
+      if (lookahead == '_') ADVANCE(198);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 139:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'y') ADVANCE(77);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(10);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 140:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(150);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F')) ADVANCE(197);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'a') ADVANCE(185);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 141:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(236);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F')) ADVANCE(235);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'a') ADVANCE(175);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 142:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(143);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F')) ADVANCE(52);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'a') ADVANCE(164);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 143:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(141);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F')) ADVANCE(50);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'a') ADVANCE(165);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 144:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(145);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F')) ADVANCE(53);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'a') ADVANCE(167);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 145:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(140);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F')) ADVANCE(51);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'b') ADVANCE(143);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 146:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(142);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F')) ADVANCE(54);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'c') ADVANCE(142);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 147:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(144);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F')) ADVANCE(55);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'c') ADVANCE(180);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 148:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(146);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F')) ADVANCE(56);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'c') ADVANCE(144);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 149:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(147);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F')) ADVANCE(57);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'd') ADVANCE(294);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 150:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'd') ADVANCE(296);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 151:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == 'a') ADVANCE(164);
-      if (('b' <= lookahead && lookahead <= 'z')) ADVANCE(171);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'd') ADVANCE(272);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 152:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == 'b') ADVANCE(162);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(171);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'e') ADVANCE(140);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 153:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == 'd') ADVANCE(240);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(171);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'e') ADVANCE(151);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 154:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == 'e') ADVANCE(238);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(171);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'e') ADVANCE(186);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 155:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == 'e') ADVANCE(170);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(171);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'f') ADVANCE(193);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 156:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == 'e') ADVANCE(168);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(171);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'h') ADVANCE(196);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 157:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == 'e') ADVANCE(230);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(171);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'h') ADVANCE(158);
+      if (lookahead == 'u') ADVANCE(184);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 158:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == 'f') ADVANCE(161);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(171);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'i') ADVANCE(155);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 159:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == 'g') ADVANCE(173);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(171);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'i') ADVANCE(148);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 160:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == 'i') ADVANCE(163);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(171);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'l') ADVANCE(162);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 161:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == 'i') ADVANCE(159);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(171);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'l') ADVANCE(152);
+      if (lookahead == 'm') ADVANCE(149);
+      if (lookahead == 'o') ADVANCE(171);
+      if (lookahead == 't') ADVANCE(187);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 162:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == 'i') ADVANCE(166);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(171);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'l') ADVANCE(266);
+      if (lookahead == 't') ADVANCE(286);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 163:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == 'l') ADVANCE(154);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(171);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'l') ADVANCE(282);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 164:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == 'l') ADVANCE(156);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(171);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'l') ADVANCE(270);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 165:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == 'n') ADVANCE(158);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(171);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'l') ADVANCE(268);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 166:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == 'n') ADVANCE(153);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(171);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'l') ADVANCE(284);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 167:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == 'o') ADVANCE(165);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(171);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'l') ADVANCE(275);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 168:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == 't') ADVANCE(169);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(171);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'l') ADVANCE(179);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 169:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == 't') ADVANCE(157);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(171);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'l') ADVANCE(191);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 170:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == 'y') ADVANCE(152);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(171);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'm') ADVANCE(149);
+      if (lookahead == 'o') ADVANCE(171);
+      if (lookahead == 't') ADVANCE(187);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 171:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(62);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(171);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'm') ADVANCE(173);
+      if (lookahead == 'n') ADVANCE(194);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 172:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(21);
-      if (lookahead == '_') ADVANCE(279);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'm') ADVANCE(153);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 173:
-      ACCEPT_TOKEN(sym_property);
-      if (lookahead == '-') ADVANCE(21);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(171);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'm') ADVANCE(141);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 174:
-      ACCEPT_TOKEN(anon_sym_true);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'n') ADVANCE(288);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 175:
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'n') ADVANCE(150);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      END_STATE();
+    case 176:
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'n') ADVANCE(147);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      END_STATE();
+    case 177:
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'n') ADVANCE(189);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      END_STATE();
+    case 178:
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'o') ADVANCE(146);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      END_STATE();
+    case 179:
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'o') ADVANCE(145);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      END_STATE();
+    case 180:
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'o') ADVANCE(177);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      END_STATE();
+    case 181:
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'o') ADVANCE(174);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      END_STATE();
+    case 182:
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'o') ADVANCE(166);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      END_STATE();
+    case 183:
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'p') ADVANCE(192);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      END_STATE();
+    case 184:
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'p') ADVANCE(154);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      END_STATE();
+    case 185:
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'r') ADVANCE(264);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      END_STATE();
+    case 186:
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'r') ADVANCE(292);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      END_STATE();
+    case 187:
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'r') ADVANCE(163);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      END_STATE();
+    case 188:
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'r') ADVANCE(182);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      END_STATE();
+    case 189:
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 's') ADVANCE(195);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      END_STATE();
+    case 190:
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 's') ADVANCE(159);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      END_STATE();
+    case 191:
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 't') ADVANCE(286);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      END_STATE();
+    case 192:
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 't') ADVANCE(290);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      END_STATE();
+    case 193:
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 't') ADVANCE(280);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      END_STATE();
+    case 194:
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 't') ADVANCE(188);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      END_STATE();
+    case 195:
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'u') ADVANCE(172);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      END_STATE();
+    case 196:
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'y') ADVANCE(190);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      END_STATE();
+    case 197:
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      END_STATE();
+    case 198:
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      END_STATE();
+    case 199:
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(227);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(227);
+      END_STATE();
+    case 200:
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(201);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(18);
+      END_STATE();
+    case 201:
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(199);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(16);
+      END_STATE();
+    case 202:
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(200);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(20);
+      END_STATE();
+    case 203:
+      ACCEPT_TOKEN(anon_sym_true);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 204:
       ACCEPT_TOKEN(anon_sym_true);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(228);
+          lookahead != '\r') ADVANCE(252);
       END_STATE();
-    case 176:
+    case 205:
       ACCEPT_TOKEN(anon_sym_false);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
-    case 177:
+    case 206:
       ACCEPT_TOKEN(anon_sym_false);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(228);
+          lookahead != '\r') ADVANCE(252);
       END_STATE();
-    case 178:
+    case 207:
       ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '%') ADVANCE(199);
-      if (lookahead == '.') ADVANCE(220);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(179);
+      if (lookahead == '%') ADVANCE(228);
+      if (lookahead == '.') ADVANCE(14);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(227);
       if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(227);
+      END_STATE();
+    case 208:
+      ACCEPT_TOKEN(sym_number_literal);
+      if (lookahead == '%') ADVANCE(228);
+      if (lookahead == '.') ADVANCE(14);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(209);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(18);
+      END_STATE();
+    case 209:
+      ACCEPT_TOKEN(sym_number_literal);
+      if (lookahead == '%') ADVANCE(228);
+      if (lookahead == '.') ADVANCE(14);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(207);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(16);
+      END_STATE();
+    case 210:
+      ACCEPT_TOKEN(sym_number_literal);
+      if (lookahead == '%') ADVANCE(228);
+      if (lookahead == '.') ADVANCE(14);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(208);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(20);
+      END_STATE();
+    case 211:
+      ACCEPT_TOKEN(sym_number_literal);
+      if (lookahead == '%') ADVANCE(228);
+      if (lookahead == '.') ADVANCE(14);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(210);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(22);
+      END_STATE();
+    case 212:
+      ACCEPT_TOKEN(sym_number_literal);
+      if (lookahead == '%') ADVANCE(228);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(212);
+      END_STATE();
+    case 213:
+      ACCEPT_TOKEN(sym_number_literal);
+      if (lookahead == '%') ADVANCE(229);
+      if (lookahead == '.') ADVANCE(244);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(227);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(227);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(228);
+          lookahead != '\r') ADVANCE(252);
       END_STATE();
-    case 179:
+    case 214:
       ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '%') ADVANCE(199);
-      if (lookahead == '.') ADVANCE(220);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(179);
+      if (lookahead == '%') ADVANCE(229);
+      if (lookahead == '.') ADVANCE(244);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(215);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(247);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(228);
+          lookahead != '\r') ADVANCE(252);
       END_STATE();
-    case 180:
+    case 215:
       ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '%') ADVANCE(199);
-      if (lookahead == '.') ADVANCE(220);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(181);
+      if (lookahead == '%') ADVANCE(229);
+      if (lookahead == '.') ADVANCE(244);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(213);
       if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(223);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(246);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(228);
+          lookahead != '\r') ADVANCE(252);
       END_STATE();
-    case 181:
+    case 216:
       ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '%') ADVANCE(199);
-      if (lookahead == '.') ADVANCE(220);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(178);
+      if (lookahead == '%') ADVANCE(229);
+      if (lookahead == '.') ADVANCE(244);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(214);
       if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(222);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(248);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(228);
+          lookahead != '\r') ADVANCE(252);
       END_STATE();
-    case 182:
+    case 217:
       ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '%') ADVANCE(199);
-      if (lookahead == '.') ADVANCE(220);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(180);
+      if (lookahead == '%') ADVANCE(229);
+      if (lookahead == '.') ADVANCE(244);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(216);
       if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(224);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(249);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(228);
+          lookahead != '\r') ADVANCE(252);
       END_STATE();
-    case 183:
+    case 218:
       ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '%') ADVANCE(199);
-      if (lookahead == '.') ADVANCE(220);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(182);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(225);
+      if (lookahead == '%') ADVANCE(229);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(218);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(228);
+          lookahead != '\r') ADVANCE(252);
       END_STATE();
-    case 184:
-      ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '%') ADVANCE(199);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(184);
+    case 219:
+      ACCEPT_TOKEN(anon_sym_DQUOTE);
+      END_STATE();
+    case 220:
+      ACCEPT_TOKEN(anon_sym_DQUOTE);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(228);
+          lookahead != '\r') ADVANCE(252);
       END_STATE();
-    case 185:
-      ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '.') ADVANCE(49);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(237);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(235);
+    case 221:
+      ACCEPT_TOKEN(aux_sym_string_literal_token1);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(221);
+      if (lookahead != 0 &&
+          lookahead != '"') ADVANCE(222);
       END_STATE();
-    case 186:
-      ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '.') ADVANCE(49);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(186);
+    case 222:
+      ACCEPT_TOKEN(aux_sym_string_literal_token1);
+      if (lookahead != 0 &&
+          lookahead != '"') ADVANCE(222);
       END_STATE();
-    case 187:
-      ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '.') ADVANCE(49);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(186);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(197);
+    case 223:
+      ACCEPT_TOKEN(anon_sym_SQUOTE);
       END_STATE();
-    case 188:
-      ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '.') ADVANCE(49);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(190);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(52);
+    case 224:
+      ACCEPT_TOKEN(anon_sym_SQUOTE);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(252);
       END_STATE();
-    case 189:
-      ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '.') ADVANCE(49);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(191);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(53);
+    case 225:
+      ACCEPT_TOKEN(aux_sym_string_literal_token2);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(225);
+      if (lookahead != 0 &&
+          lookahead != '\'') ADVANCE(226);
       END_STATE();
-    case 190:
-      ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '.') ADVANCE(49);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(185);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(50);
+    case 226:
+      ACCEPT_TOKEN(aux_sym_string_literal_token2);
+      if (lookahead != 0 &&
+          lookahead != '\'') ADVANCE(226);
       END_STATE();
-    case 191:
-      ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '.') ADVANCE(49);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(187);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(51);
-      END_STATE();
-    case 192:
-      ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '.') ADVANCE(49);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(188);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(54);
-      END_STATE();
-    case 193:
-      ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '.') ADVANCE(49);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(189);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(55);
-      END_STATE();
-    case 194:
-      ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '.') ADVANCE(49);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(192);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(56);
-      END_STATE();
-    case 195:
-      ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '.') ADVANCE(49);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(193);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(57);
-      END_STATE();
-    case 196:
-      ACCEPT_TOKEN(sym_number_literal);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(196);
-      END_STATE();
-    case 197:
+    case 227:
       ACCEPT_TOKEN(sym_color_value);
       END_STATE();
-    case 198:
-      ACCEPT_TOKEN(sym_color_value);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(228);
+    case 228:
+      ACCEPT_TOKEN(sym_percent_adjustment);
       END_STATE();
-    case 199:
+    case 229:
       ACCEPT_TOKEN(sym_percent_adjustment);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(228);
+          lookahead != '\r') ADVANCE(252);
       END_STATE();
-    case 200:
+    case 230:
       ACCEPT_TOKEN(sym_numeric_adjustment);
-      if (lookahead == '%') ADVANCE(199);
-      if (lookahead == '.') ADVANCE(221);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(200);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(228);
+      if (lookahead == '%') ADVANCE(228);
+      if (lookahead == '.') ADVANCE(15);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(230);
       END_STATE();
-    case 201:
+    case 231:
       ACCEPT_TOKEN(sym_numeric_adjustment);
-      if (lookahead == '%') ADVANCE(199);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(201);
+      if (lookahead == '%') ADVANCE(228);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(231);
+      END_STATE();
+    case 232:
+      ACCEPT_TOKEN(sym_numeric_adjustment);
+      if (lookahead == '%') ADVANCE(229);
+      if (lookahead == '.') ADVANCE(245);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(232);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(228);
+          lookahead != '\r') ADVANCE(252);
       END_STATE();
-    case 202:
-      ACCEPT_TOKEN(anon_sym_DQUOTE);
-      END_STATE();
-    case 203:
-      ACCEPT_TOKEN(anon_sym_DQUOTE);
+    case 233:
+      ACCEPT_TOKEN(sym_numeric_adjustment);
+      if (lookahead == '%') ADVANCE(229);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(233);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(228);
+          lookahead != '\r') ADVANCE(252);
       END_STATE();
-    case 204:
-      ACCEPT_TOKEN(aux_sym_string_literal_token1);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(204);
-      if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(205);
-      END_STATE();
-    case 205:
-      ACCEPT_TOKEN(aux_sym_string_literal_token1);
-      if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(205);
-      END_STATE();
-    case 206:
-      ACCEPT_TOKEN(anon_sym_SQUOTE);
-      END_STATE();
-    case 207:
-      ACCEPT_TOKEN(anon_sym_SQUOTE);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(228);
-      END_STATE();
-    case 208:
-      ACCEPT_TOKEN(aux_sym_string_literal_token2);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(208);
-      if (lookahead != 0 &&
-          lookahead != '\'') ADVANCE(209);
-      END_STATE();
-    case 209:
-      ACCEPT_TOKEN(aux_sym_string_literal_token2);
-      if (lookahead != 0 &&
-          lookahead != '\'') ADVANCE(209);
-      END_STATE();
-    case 210:
+    case 234:
       ACCEPT_TOKEN(aux_sym_raw_value_token1);
       ADVANCE_MAP(
-        '\n', 68,
+        '\n', 34,
         '\r', 4,
-        '"', 203,
-        '#', 227,
-        '\'', 207,
-        'f', 211,
-        't', 215,
-        '+', 219,
-        '-', 219,
-        '\t', 210,
-        0x0b, 210,
-        '\f', 210,
-        ' ', 210,
+        '"', 220,
+        '#', 251,
+        '\'', 224,
+        'f', 235,
+        't', 239,
+        '+', 243,
+        '-', 243,
+        '\t', 234,
+        0x0b, 234,
+        '\f', 234,
+        ' ', 234,
       );
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(183);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(217);
       if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'e')) ADVANCE(226);
-      if (lookahead != 0) ADVANCE(228);
+          ('a' <= lookahead && lookahead <= 'e')) ADVANCE(250);
+      if (lookahead != 0) ADVANCE(252);
       END_STATE();
-    case 211:
+    case 235:
       ACCEPT_TOKEN(aux_sym_raw_value_token1);
-      if (lookahead == 'a') ADVANCE(214);
+      if (lookahead == 'a') ADVANCE(238);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('b' <= lookahead && lookahead <= 'f')) ADVANCE(225);
+          ('b' <= lookahead && lookahead <= 'f')) ADVANCE(249);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(228);
+          lookahead != '\r') ADVANCE(252);
       END_STATE();
-    case 212:
+    case 236:
       ACCEPT_TOKEN(aux_sym_raw_value_token1);
-      if (lookahead == 'e') ADVANCE(175);
+      if (lookahead == 'e') ADVANCE(204);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(228);
+          lookahead != '\r') ADVANCE(252);
       END_STATE();
-    case 213:
+    case 237:
       ACCEPT_TOKEN(aux_sym_raw_value_token1);
-      if (lookahead == 'e') ADVANCE(177);
+      if (lookahead == 'e') ADVANCE(206);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(228);
+          lookahead != '\r') ADVANCE(252);
       END_STATE();
-    case 214:
+    case 238:
       ACCEPT_TOKEN(aux_sym_raw_value_token1);
-      if (lookahead == 'l') ADVANCE(216);
+      if (lookahead == 'l') ADVANCE(240);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(224);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(248);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(228);
+          lookahead != '\r') ADVANCE(252);
       END_STATE();
-    case 215:
+    case 239:
       ACCEPT_TOKEN(aux_sym_raw_value_token1);
-      if (lookahead == 'r') ADVANCE(217);
+      if (lookahead == 'r') ADVANCE(241);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(228);
+          lookahead != '\r') ADVANCE(252);
       END_STATE();
-    case 216:
+    case 240:
       ACCEPT_TOKEN(aux_sym_raw_value_token1);
-      if (lookahead == 's') ADVANCE(213);
+      if (lookahead == 's') ADVANCE(237);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(228);
+          lookahead != '\r') ADVANCE(252);
       END_STATE();
-    case 217:
+    case 241:
       ACCEPT_TOKEN(aux_sym_raw_value_token1);
-      if (lookahead == 'u') ADVANCE(212);
+      if (lookahead == 'u') ADVANCE(236);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(228);
+          lookahead != '\r') ADVANCE(252);
       END_STATE();
-    case 218:
+    case 242:
       ACCEPT_TOKEN(aux_sym_raw_value_token1);
       if (lookahead == '\t' ||
           lookahead == 0x0b ||
           lookahead == '\f' ||
-          lookahead == ' ') ADVANCE(218);
+          lookahead == ' ') ADVANCE(242);
       if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(228);
-      END_STATE();
-    case 219:
-      ACCEPT_TOKEN(aux_sym_raw_value_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(200);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(228);
-      END_STATE();
-    case 220:
-      ACCEPT_TOKEN(aux_sym_raw_value_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(184);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(228);
-      END_STATE();
-    case 221:
-      ACCEPT_TOKEN(aux_sym_raw_value_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(201);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(228);
-      END_STATE();
-    case 222:
-      ACCEPT_TOKEN(aux_sym_raw_value_token1);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(198);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(228);
-      END_STATE();
-    case 223:
-      ACCEPT_TOKEN(aux_sym_raw_value_token1);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(222);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(228);
-      END_STATE();
-    case 224:
-      ACCEPT_TOKEN(aux_sym_raw_value_token1);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(223);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(228);
-      END_STATE();
-    case 225:
-      ACCEPT_TOKEN(aux_sym_raw_value_token1);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(224);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(228);
-      END_STATE();
-    case 226:
-      ACCEPT_TOKEN(aux_sym_raw_value_token1);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(225);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(228);
-      END_STATE();
-    case 227:
-      ACCEPT_TOKEN(aux_sym_raw_value_token1);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(226);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(228);
-      END_STATE();
-    case 228:
-      ACCEPT_TOKEN(aux_sym_raw_value_token1);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(228);
-      END_STATE();
-    case 229:
-      ACCEPT_TOKEN(anon_sym_palette);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
-      END_STATE();
-    case 230:
-      ACCEPT_TOKEN(anon_sym_palette);
-      if (lookahead == '-') ADVANCE(62);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(171);
-      END_STATE();
-    case 231:
-      ACCEPT_TOKEN(aux_sym_palette_value_token1);
-      END_STATE();
-    case 232:
-      ACCEPT_TOKEN(aux_sym_palette_value_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(231);
-      END_STATE();
-    case 233:
-      ACCEPT_TOKEN(aux_sym_palette_value_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(232);
-      END_STATE();
-    case 234:
-      ACCEPT_TOKEN(anon_sym_EQ2);
-      END_STATE();
-    case 235:
-      ACCEPT_TOKEN(aux_sym_palette_value_token2);
-      END_STATE();
-    case 236:
-      ACCEPT_TOKEN(aux_sym_palette_value_token2);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
-      END_STATE();
-    case 237:
-      ACCEPT_TOKEN(aux_sym_palette_value_token2);
-      if (lookahead == '.') ADVANCE(49);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(186);
-      END_STATE();
-    case 238:
-      ACCEPT_TOKEN(anon_sym_config_DASHfile);
-      if (lookahead == '-') ADVANCE(62);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(171);
-      END_STATE();
-    case 239:
-      ACCEPT_TOKEN(anon_sym_keybind);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
-      END_STATE();
-    case 240:
-      ACCEPT_TOKEN(anon_sym_keybind);
-      if (lookahead == '-') ADVANCE(62);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(171);
-      END_STATE();
-    case 241:
-      ACCEPT_TOKEN(anon_sym_all);
-      END_STATE();
-    case 242:
-      ACCEPT_TOKEN(anon_sym_all);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(252);
       END_STATE();
     case 243:
-      ACCEPT_TOKEN(anon_sym_global);
+      ACCEPT_TOKEN(aux_sym_raw_value_token1);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(232);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(252);
       END_STATE();
     case 244:
-      ACCEPT_TOKEN(anon_sym_global);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(aux_sym_raw_value_token1);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(218);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(252);
       END_STATE();
     case 245:
-      ACCEPT_TOKEN(anon_sym_local);
+      ACCEPT_TOKEN(aux_sym_raw_value_token1);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(233);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(252);
       END_STATE();
     case 246:
-      ACCEPT_TOKEN(anon_sym_local);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(aux_sym_raw_value_token1);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(227);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(252);
       END_STATE();
     case 247:
-      ACCEPT_TOKEN(anon_sym_unconsumed);
+      ACCEPT_TOKEN(aux_sym_raw_value_token1);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(246);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(252);
       END_STATE();
     case 248:
-      ACCEPT_TOKEN(anon_sym_unconsumed);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(aux_sym_raw_value_token1);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(247);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(252);
       END_STATE();
     case 249:
-      ACCEPT_TOKEN(anon_sym_COLON);
+      ACCEPT_TOKEN(aux_sym_raw_value_token1);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(248);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(252);
       END_STATE();
     case 250:
-      ACCEPT_TOKEN(anon_sym_GT);
+      ACCEPT_TOKEN(aux_sym_raw_value_token1);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(249);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(252);
       END_STATE();
     case 251:
-      ACCEPT_TOKEN(anon_sym_PLUS);
+      ACCEPT_TOKEN(aux_sym_raw_value_token1);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(250);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(252);
       END_STATE();
     case 252:
-      ACCEPT_TOKEN(anon_sym_shift);
+      ACCEPT_TOKEN(aux_sym_raw_value_token1);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(252);
       END_STATE();
     case 253:
-      ACCEPT_TOKEN(anon_sym_shift);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(anon_sym_palette);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 254:
-      ACCEPT_TOKEN(anon_sym_ctrl);
+      ACCEPT_TOKEN(anon_sym_palette);
+      if (lookahead == '-') ADVANCE(28);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 255:
-      ACCEPT_TOKEN(anon_sym_ctrl);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(aux_sym_palette_value_token1);
       END_STATE();
     case 256:
-      ACCEPT_TOKEN(anon_sym_control);
+      ACCEPT_TOKEN(aux_sym_palette_value_token1);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(255);
       END_STATE();
     case 257:
-      ACCEPT_TOKEN(anon_sym_control);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(aux_sym_palette_value_token1);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(256);
       END_STATE();
     case 258:
-      ACCEPT_TOKEN(anon_sym_alt);
+      ACCEPT_TOKEN(anon_sym_EQ2);
       END_STATE();
     case 259:
-      ACCEPT_TOKEN(anon_sym_alt);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(aux_sym_palette_value_token2);
       END_STATE();
     case 260:
-      ACCEPT_TOKEN(anon_sym_option);
+      ACCEPT_TOKEN(anon_sym_config_DASHfile);
+      if (lookahead == '-') ADVANCE(28);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 261:
-      ACCEPT_TOKEN(anon_sym_option);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(anon_sym_keybind);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 262:
-      ACCEPT_TOKEN(anon_sym_opt);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (lookahead == 'i') ADVANCE(123);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(anon_sym_keybind);
+      if (lookahead == '-') ADVANCE(28);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 263:
-      ACCEPT_TOKEN(anon_sym_opt);
-      if (lookahead == 'i') ADVANCE(37);
+      ACCEPT_TOKEN(anon_sym_clear);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 264:
-      ACCEPT_TOKEN(anon_sym_super);
+      ACCEPT_TOKEN(anon_sym_clear);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 265:
-      ACCEPT_TOKEN(anon_sym_super);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(anon_sym_all);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 266:
-      ACCEPT_TOKEN(anon_sym_cmd);
+      ACCEPT_TOKEN(anon_sym_all);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 267:
-      ACCEPT_TOKEN(anon_sym_cmd);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(anon_sym_global);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 268:
-      ACCEPT_TOKEN(anon_sym_command);
+      ACCEPT_TOKEN(anon_sym_global);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 269:
-      ACCEPT_TOKEN(anon_sym_command);
-      if (lookahead == '-') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(279);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(anon_sym_local);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 270:
-      ACCEPT_TOKEN(sym_key);
+      ACCEPT_TOKEN(anon_sym_local);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 271:
-      ACCEPT_TOKEN(sym_key);
-      if (lookahead == 'a') ADVANCE(273);
-      if (lookahead == 'c') ADVANCE(275);
-      if (lookahead == 'g') ADVANCE(274);
-      if (lookahead == 'l') ADVANCE(277);
-      if (lookahead == 'o') ADVANCE(278);
-      if (lookahead == 's') ADVANCE(272);
-      if (lookahead == 'u') ADVANCE(276);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(271);
-      if (lookahead != 0 &&
-          lookahead != ':' &&
-          lookahead != '=' &&
-          lookahead != '>') ADVANCE(270);
+      ACCEPT_TOKEN(anon_sym_unconsumed);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 272:
-      ACCEPT_TOKEN(sym_key);
-      if (lookahead == 'h') ADVANCE(23);
-      if (lookahead == 'u') ADVANCE(39);
+      ACCEPT_TOKEN(anon_sym_unconsumed);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 273:
-      ACCEPT_TOKEN(sym_key);
-      if (lookahead == 'l') ADVANCE(24);
+      ACCEPT_TOKEN(anon_sym_COLON);
       END_STATE();
     case 274:
-      ACCEPT_TOKEN(sym_key);
-      if (lookahead == 'l') ADVANCE(35);
+      ACCEPT_TOKEN(sym_key_prefix);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
       END_STATE();
     case 275:
-      ACCEPT_TOKEN(sym_key);
-      if (lookahead == 'm') ADVANCE(16);
-      if (lookahead == 'o') ADVANCE(29);
-      if (lookahead == 't') ADVANCE(40);
+      ACCEPT_TOKEN(sym_key_prefix);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 276:
-      ACCEPT_TOKEN(sym_key);
-      if (lookahead == 'n') ADVANCE(15);
+      ACCEPT_TOKEN(anon_sym_GT);
       END_STATE();
     case 277:
-      ACCEPT_TOKEN(sym_key);
-      if (lookahead == 'o') ADVANCE(14);
+      ACCEPT_TOKEN(anon_sym_PLUS);
       END_STATE();
     case 278:
-      ACCEPT_TOKEN(sym_key);
-      if (lookahead == 'p') ADVANCE(44);
+      ACCEPT_TOKEN(anon_sym_PLUS);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(230);
       END_STATE();
     case 279:
-      ACCEPT_TOKEN(aux_sym_keybind_action_token1);
+      ACCEPT_TOKEN(anon_sym_shift);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 280:
+      ACCEPT_TOKEN(anon_sym_shift);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(279);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      END_STATE();
+    case 281:
+      ACCEPT_TOKEN(anon_sym_ctrl);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 282:
+      ACCEPT_TOKEN(anon_sym_ctrl);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      END_STATE();
+    case 283:
+      ACCEPT_TOKEN(anon_sym_control);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 284:
+      ACCEPT_TOKEN(anon_sym_control);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      END_STATE();
+    case 285:
+      ACCEPT_TOKEN(anon_sym_alt);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 286:
+      ACCEPT_TOKEN(anon_sym_alt);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      END_STATE();
+    case 287:
+      ACCEPT_TOKEN(anon_sym_option);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 288:
+      ACCEPT_TOKEN(anon_sym_option);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      END_STATE();
+    case 289:
+      ACCEPT_TOKEN(anon_sym_opt);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == 'i') ADVANCE(91);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 290:
+      ACCEPT_TOKEN(anon_sym_opt);
+      if (lookahead == 'i') ADVANCE(181);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      END_STATE();
+    case 291:
+      ACCEPT_TOKEN(anon_sym_super);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 292:
+      ACCEPT_TOKEN(anon_sym_super);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      END_STATE();
+    case 293:
+      ACCEPT_TOKEN(anon_sym_cmd);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 294:
+      ACCEPT_TOKEN(anon_sym_cmd);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      END_STATE();
+    case 295:
+      ACCEPT_TOKEN(anon_sym_command);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(198);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      END_STATE();
+    case 296:
+      ACCEPT_TOKEN(anon_sym_command);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     default:
       return false;
@@ -2406,89 +2877,101 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 63},
-  [2] = {.lex_state = 9},
-  [3] = {.lex_state = 9},
-  [4] = {.lex_state = 9},
+  [1] = {.lex_state = 29},
+  [2] = {.lex_state = 5},
+  [3] = {.lex_state = 8},
+  [4] = {.lex_state = 8},
   [5] = {.lex_state = 4},
-  [6] = {.lex_state = 9},
-  [7] = {.lex_state = 63},
-  [8] = {.lex_state = 63},
+  [6] = {.lex_state = 8},
+  [7] = {.lex_state = 29},
+  [8] = {.lex_state = 29},
   [9] = {.lex_state = 9},
   [10] = {.lex_state = 9},
-  [11] = {.lex_state = 63},
-  [12] = {.lex_state = 63},
-  [13] = {.lex_state = 63},
-  [14] = {.lex_state = 63},
-  [15] = {.lex_state = 63},
-  [16] = {.lex_state = 63},
-  [17] = {.lex_state = 63},
-  [18] = {.lex_state = 6},
-  [19] = {.lex_state = 6},
-  [20] = {.lex_state = 6},
-  [21] = {.lex_state = 6},
-  [22] = {.lex_state = 63},
-  [23] = {.lex_state = 6},
-  [24] = {.lex_state = 6},
-  [25] = {.lex_state = 6},
-  [26] = {.lex_state = 6},
-  [27] = {.lex_state = 6},
-  [28] = {.lex_state = 48},
-  [29] = {.lex_state = 63},
-  [30] = {.lex_state = 6},
-  [31] = {.lex_state = 48},
-  [32] = {.lex_state = 6},
-  [33] = {.lex_state = 5},
-  [34] = {.lex_state = 63},
-  [35] = {.lex_state = 63},
-  [36] = {.lex_state = 5},
-  [37] = {.lex_state = 5},
-  [38] = {.lex_state = 0},
-  [39] = {.lex_state = 208},
-  [40] = {.lex_state = 63},
-  [41] = {.lex_state = 63},
-  [42] = {.lex_state = 63},
-  [43] = {.lex_state = 0},
-  [44] = {.lex_state = 63},
-  [45] = {.lex_state = 63},
-  [46] = {.lex_state = 63},
-  [47] = {.lex_state = 204},
-  [48] = {.lex_state = 63},
-  [49] = {.lex_state = 63},
-  [50] = {.lex_state = 5},
-  [51] = {.lex_state = 63},
-  [52] = {.lex_state = 63},
-  [53] = {.lex_state = 63},
-  [54] = {.lex_state = 5},
-  [55] = {.lex_state = 63},
-  [56] = {.lex_state = 0},
-  [57] = {.lex_state = 0},
-  [58] = {.lex_state = 63},
-  [59] = {.lex_state = 63},
+  [11] = {.lex_state = 29},
+  [12] = {.lex_state = 29},
+  [13] = {.lex_state = 29},
+  [14] = {.lex_state = 29},
+  [15] = {.lex_state = 29},
+  [16] = {.lex_state = 29},
+  [17] = {.lex_state = 29},
+  [18] = {.lex_state = 5},
+  [19] = {.lex_state = 5},
+  [20] = {.lex_state = 5},
+  [21] = {.lex_state = 5},
+  [22] = {.lex_state = 5},
+  [23] = {.lex_state = 5},
+  [24] = {.lex_state = 5},
+  [25] = {.lex_state = 5},
+  [26] = {.lex_state = 29},
+  [27] = {.lex_state = 5},
+  [28] = {.lex_state = 5},
+  [29] = {.lex_state = 11},
+  [30] = {.lex_state = 12},
+  [31] = {.lex_state = 29},
+  [32] = {.lex_state = 5},
+  [33] = {.lex_state = 11},
+  [34] = {.lex_state = 12},
+  [35] = {.lex_state = 29},
+  [36] = {.lex_state = 8},
+  [37] = {.lex_state = 29},
+  [38] = {.lex_state = 7},
+  [39] = {.lex_state = 0},
+  [40] = {.lex_state = 221},
+  [41] = {.lex_state = 0},
+  [42] = {.lex_state = 0},
+  [43] = {.lex_state = 8},
+  [44] = {.lex_state = 12},
+  [45] = {.lex_state = 225},
+  [46] = {.lex_state = 29},
+  [47] = {.lex_state = 8},
+  [48] = {.lex_state = 0},
+  [49] = {.lex_state = 0},
+  [50] = {.lex_state = 29},
+  [51] = {.lex_state = 29},
+  [52] = {.lex_state = 29},
+  [53] = {.lex_state = 29},
+  [54] = {.lex_state = 29},
+  [55] = {.lex_state = 29},
+  [56] = {.lex_state = 29},
+  [57] = {.lex_state = 29},
+  [58] = {.lex_state = 29},
+  [59] = {.lex_state = 8},
+  [60] = {.lex_state = 29},
+  [61] = {.lex_state = 29},
+  [62] = {.lex_state = 29},
+  [63] = {.lex_state = 29},
+  [64] = {.lex_state = 8},
+  [65] = {.lex_state = 29},
+  [66] = {.lex_state = 29},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
   [0] = {
     [ts_builtin_sym_end] = ACTIONS(1),
     [anon_sym_EQ] = ACTIONS(1),
-    [sym_property] = ACTIONS(1),
+    [sym__kebab_case_identifier] = ACTIONS(1),
+    [sym__snake_case_identifier] = ACTIONS(1),
     [anon_sym_true] = ACTIONS(1),
     [anon_sym_false] = ACTIONS(1),
     [sym_number_literal] = ACTIONS(1),
-    [sym_color_value] = ACTIONS(1),
     [anon_sym_DQUOTE] = ACTIONS(1),
     [anon_sym_SQUOTE] = ACTIONS(1),
+    [sym_color_value] = ACTIONS(1),
+    [sym_percent_adjustment] = ACTIONS(1),
+    [sym_numeric_adjustment] = ACTIONS(1),
     [anon_sym_palette] = ACTIONS(1),
     [aux_sym_palette_value_token1] = ACTIONS(1),
     [anon_sym_EQ2] = ACTIONS(1),
     [aux_sym_palette_value_token2] = ACTIONS(1),
     [anon_sym_config_DASHfile] = ACTIONS(1),
     [anon_sym_keybind] = ACTIONS(1),
+    [anon_sym_clear] = ACTIONS(1),
     [anon_sym_all] = ACTIONS(1),
     [anon_sym_global] = ACTIONS(1),
     [anon_sym_local] = ACTIONS(1),
     [anon_sym_unconsumed] = ACTIONS(1),
     [anon_sym_COLON] = ACTIONS(1),
+    [sym_key_prefix] = ACTIONS(1),
     [anon_sym_GT] = ACTIONS(1),
     [anon_sym_PLUS] = ACTIONS(1),
     [anon_sym_shift] = ACTIONS(1),
@@ -2500,20 +2983,20 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_super] = ACTIONS(1),
     [anon_sym_cmd] = ACTIONS(1),
     [anon_sym_command] = ACTIONS(1),
-    [aux_sym_keybind_action_token1] = ACTIONS(1),
   },
   [1] = {
-    [sym_source_file] = STATE(38),
-    [sym_directive] = STATE(7),
+    [sym_source_file] = STATE(39),
+    [sym_directive] = STATE(8),
     [sym_basic_directive] = STATE(11),
+    [sym_property] = STATE(43),
     [sym_palette_directive] = STATE(11),
     [sym_config_file_directive] = STATE(11),
     [sym_keybind_directive] = STATE(11),
-    [aux_sym_source_file_repeat1] = STATE(7),
+    [aux_sym_source_file_repeat1] = STATE(8),
     [ts_builtin_sym_end] = ACTIONS(3),
     [aux_sym_source_file_token1] = ACTIONS(5),
     [sym_comment] = ACTIONS(7),
-    [sym_property] = ACTIONS(9),
+    [sym__kebab_case_identifier] = ACTIONS(9),
     [anon_sym_palette] = ACTIONS(11),
     [anon_sym_config_DASHfile] = ACTIONS(13),
     [anon_sym_keybind] = ACTIONS(15),
@@ -2521,27 +3004,38 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
 };
 
 static const uint16_t ts_small_parse_table[] = {
-  [0] = 8,
+  [0] = 13,
+    ACTIONS(17), 1,
+      sym__snake_case_identifier,
+    ACTIONS(19), 1,
+      anon_sym_DQUOTE,
     ACTIONS(21), 1,
-      sym_key,
-    STATE(18), 1,
-      sym_key_modifier,
-    STATE(25), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(23), 1,
+      anon_sym_clear,
+    ACTIONS(27), 1,
+      sym_key_prefix,
+    STATE(21), 1,
       sym_chord,
-    STATE(52), 1,
+    STATE(46), 1,
+      sym_string_literal,
+    STATE(53), 1,
       sym_keybind_trigger,
     STATE(3), 2,
       sym_keybind_modifier,
       aux_sym_keybind_value_repeat1,
-    STATE(51), 2,
+    STATE(18), 2,
+      sym_key_modifier,
+      sym_key,
+    STATE(52), 2,
       sym__keybind_value,
       sym_keybind_value,
-    ACTIONS(17), 4,
+    ACTIONS(25), 4,
       anon_sym_all,
       anon_sym_global,
       anon_sym_local,
       anon_sym_unconsumed,
-    ACTIONS(19), 9,
+    ACTIONS(29), 9,
       anon_sym_shift,
       anon_sym_ctrl,
       anon_sym_control,
@@ -2551,24 +3045,27 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_super,
       anon_sym_cmd,
       anon_sym_command,
-  [38] = 7,
-    ACTIONS(21), 1,
-      sym_key,
-    STATE(18), 1,
-      sym_key_modifier,
-    STATE(25), 1,
+  [54] = 8,
+    ACTIONS(17), 1,
+      sym__snake_case_identifier,
+    ACTIONS(27), 1,
+      sym_key_prefix,
+    STATE(21), 1,
       sym_chord,
-    STATE(46), 1,
+    STATE(51), 1,
       sym_keybind_trigger,
     STATE(4), 2,
       sym_keybind_modifier,
       aux_sym_keybind_value_repeat1,
-    ACTIONS(17), 4,
+    STATE(18), 2,
+      sym_key_modifier,
+      sym_key,
+    ACTIONS(25), 4,
       anon_sym_all,
       anon_sym_global,
       anon_sym_local,
       anon_sym_unconsumed,
-    ACTIONS(19), 9,
+    ACTIONS(29), 9,
       anon_sym_shift,
       anon_sym_ctrl,
       anon_sym_control,
@@ -2578,16 +3075,18 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_super,
       anon_sym_cmd,
       anon_sym_command,
-  [72] = 3,
+  [92] = 3,
     STATE(4), 2,
       sym_keybind_modifier,
       aux_sym_keybind_value_repeat1,
-    ACTIONS(23), 4,
+    ACTIONS(33), 4,
       anon_sym_all,
       anon_sym_global,
       anon_sym_local,
       anon_sym_unconsumed,
-    ACTIONS(26), 10,
+    ACTIONS(31), 11,
+      sym__snake_case_identifier,
+      sym_key_prefix,
       anon_sym_shift,
       anon_sym_ctrl,
       anon_sym_control,
@@ -2597,38 +3096,39 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_super,
       anon_sym_cmd,
       anon_sym_command,
-      sym_key,
-  [95] = 9,
-    ACTIONS(28), 1,
-      aux_sym_source_file_token1,
+  [116] = 9,
     ACTIONS(36), 1,
+      aux_sym_source_file_token1,
+    ACTIONS(42), 1,
       anon_sym_DQUOTE,
-    ACTIONS(38), 1,
+    ACTIONS(44), 1,
       anon_sym_SQUOTE,
-    ACTIONS(40), 1,
+    ACTIONS(48), 1,
       aux_sym_raw_value_token1,
-    STATE(45), 1,
+    STATE(37), 1,
       sym_value,
-    ACTIONS(30), 2,
+    ACTIONS(38), 2,
       anon_sym_true,
       anon_sym_false,
-    ACTIONS(32), 2,
+    ACTIONS(40), 2,
       sym_number_literal,
       sym_color_value,
-    ACTIONS(34), 2,
+    ACTIONS(46), 2,
       sym_percent_adjustment,
       sym_numeric_adjustment,
-    STATE(42), 4,
+    STATE(62), 4,
       sym_boolean_literal,
       sym_adjustment,
       sym_string_literal,
       sym_raw_value,
-  [129] = 1,
-    ACTIONS(42), 14,
+  [150] = 1,
+    ACTIONS(50), 15,
+      sym__snake_case_identifier,
       anon_sym_all,
       anon_sym_global,
       anon_sym_local,
       anon_sym_unconsumed,
+      sym_key_prefix,
       anon_sym_shift,
       anon_sym_ctrl,
       anon_sym_control,
@@ -2638,46 +3138,49 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_super,
       anon_sym_cmd,
       anon_sym_command,
-      sym_key,
-  [146] = 9,
-    ACTIONS(9), 1,
+  [168] = 10,
+    ACTIONS(52), 1,
+      ts_builtin_sym_end,
+    ACTIONS(54), 1,
+      aux_sym_source_file_token1,
+    ACTIONS(57), 1,
+      sym_comment,
+    ACTIONS(60), 1,
+      sym__kebab_case_identifier,
+    ACTIONS(63), 1,
+      anon_sym_palette,
+    ACTIONS(66), 1,
+      anon_sym_config_DASHfile,
+    ACTIONS(69), 1,
+      anon_sym_keybind,
+    STATE(43), 1,
       sym_property,
+    STATE(7), 2,
+      sym_directive,
+      aux_sym_source_file_repeat1,
+    STATE(11), 4,
+      sym_basic_directive,
+      sym_palette_directive,
+      sym_config_file_directive,
+      sym_keybind_directive,
+  [203] = 10,
+    ACTIONS(9), 1,
+      sym__kebab_case_identifier,
     ACTIONS(11), 1,
       anon_sym_palette,
     ACTIONS(13), 1,
       anon_sym_config_DASHfile,
     ACTIONS(15), 1,
       anon_sym_keybind,
-    ACTIONS(44), 1,
+    ACTIONS(72), 1,
       ts_builtin_sym_end,
-    ACTIONS(46), 1,
+    ACTIONS(74), 1,
       aux_sym_source_file_token1,
-    ACTIONS(48), 1,
+    ACTIONS(76), 1,
       sym_comment,
-    STATE(8), 2,
-      sym_directive,
-      aux_sym_source_file_repeat1,
-    STATE(11), 4,
-      sym_basic_directive,
-      sym_palette_directive,
-      sym_config_file_directive,
-      sym_keybind_directive,
-  [178] = 9,
-    ACTIONS(50), 1,
-      ts_builtin_sym_end,
-    ACTIONS(52), 1,
-      aux_sym_source_file_token1,
-    ACTIONS(55), 1,
-      sym_comment,
-    ACTIONS(58), 1,
+    STATE(43), 1,
       sym_property,
-    ACTIONS(61), 1,
-      anon_sym_palette,
-    ACTIONS(64), 1,
-      anon_sym_config_DASHfile,
-    ACTIONS(67), 1,
-      anon_sym_keybind,
-    STATE(8), 2,
+    STATE(7), 2,
       sym_directive,
       aux_sym_source_file_repeat1,
     STATE(11), 4,
@@ -2685,29 +3188,17 @@ static const uint16_t ts_small_parse_table[] = {
       sym_palette_directive,
       sym_config_file_directive,
       sym_keybind_directive,
-  [210] = 4,
-    ACTIONS(21), 1,
-      sym_key,
-    STATE(18), 1,
-      sym_key_modifier,
-    STATE(30), 1,
+  [238] = 5,
+    ACTIONS(17), 1,
+      sym__snake_case_identifier,
+    ACTIONS(27), 1,
+      sym_key_prefix,
+    STATE(32), 1,
       sym_chord,
-    ACTIONS(19), 9,
-      anon_sym_shift,
-      anon_sym_ctrl,
-      anon_sym_control,
-      anon_sym_alt,
-      anon_sym_option,
-      anon_sym_opt,
-      anon_sym_super,
-      anon_sym_cmd,
-      anon_sym_command,
-  [231] = 3,
-    ACTIONS(70), 1,
-      sym_key,
-    STATE(23), 1,
+    STATE(18), 2,
       sym_key_modifier,
-    ACTIONS(19), 9,
+      sym_key,
+    ACTIONS(29), 9,
       anon_sym_shift,
       anon_sym_ctrl,
       anon_sym_control,
@@ -2717,402 +3208,463 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_super,
       anon_sym_cmd,
       anon_sym_command,
-  [249] = 2,
-    ACTIONS(72), 2,
-      ts_builtin_sym_end,
-      aux_sym_source_file_token1,
-    ACTIONS(74), 5,
-      sym_comment,
-      sym_property,
-      anon_sym_palette,
-      anon_sym_config_DASHfile,
-      anon_sym_keybind,
-  [261] = 2,
-    ACTIONS(76), 2,
-      ts_builtin_sym_end,
-      aux_sym_source_file_token1,
-    ACTIONS(78), 5,
-      sym_comment,
-      sym_property,
-      anon_sym_palette,
-      anon_sym_config_DASHfile,
-      anon_sym_keybind,
-  [273] = 2,
-    ACTIONS(80), 2,
-      ts_builtin_sym_end,
-      aux_sym_source_file_token1,
-    ACTIONS(82), 5,
-      sym_comment,
-      sym_property,
-      anon_sym_palette,
-      anon_sym_config_DASHfile,
-      anon_sym_keybind,
+  [263] = 4,
+    ACTIONS(17), 1,
+      sym__snake_case_identifier,
+    ACTIONS(27), 1,
+      sym_key_prefix,
+    STATE(28), 2,
+      sym_key_modifier,
+      sym_key,
+    ACTIONS(29), 9,
+      anon_sym_shift,
+      anon_sym_ctrl,
+      anon_sym_control,
+      anon_sym_alt,
+      anon_sym_option,
+      anon_sym_opt,
+      anon_sym_super,
+      anon_sym_cmd,
+      anon_sym_command,
   [285] = 2,
-    ACTIONS(84), 2,
+    ACTIONS(78), 2,
       ts_builtin_sym_end,
       aux_sym_source_file_token1,
-    ACTIONS(86), 5,
+    ACTIONS(80), 5,
       sym_comment,
-      sym_property,
+      sym__kebab_case_identifier,
       anon_sym_palette,
       anon_sym_config_DASHfile,
       anon_sym_keybind,
   [297] = 2,
-    ACTIONS(88), 2,
+    ACTIONS(82), 2,
       ts_builtin_sym_end,
       aux_sym_source_file_token1,
-    ACTIONS(90), 5,
+    ACTIONS(84), 5,
       sym_comment,
-      sym_property,
+      sym__kebab_case_identifier,
       anon_sym_palette,
       anon_sym_config_DASHfile,
       anon_sym_keybind,
   [309] = 2,
-    ACTIONS(92), 2,
+    ACTIONS(86), 2,
       ts_builtin_sym_end,
       aux_sym_source_file_token1,
-    ACTIONS(94), 5,
+    ACTIONS(88), 5,
       sym_comment,
-      sym_property,
+      sym__kebab_case_identifier,
       anon_sym_palette,
       anon_sym_config_DASHfile,
       anon_sym_keybind,
   [321] = 2,
-    ACTIONS(96), 2,
+    ACTIONS(90), 2,
       ts_builtin_sym_end,
       aux_sym_source_file_token1,
-    ACTIONS(98), 5,
+    ACTIONS(92), 5,
       sym_comment,
-      sym_property,
+      sym__kebab_case_identifier,
       anon_sym_palette,
       anon_sym_config_DASHfile,
       anon_sym_keybind,
-  [333] = 3,
-    ACTIONS(102), 1,
-      anon_sym_PLUS,
-    STATE(19), 1,
-      aux_sym_chord_repeat1,
-    ACTIONS(100), 2,
-      anon_sym_EQ2,
-      anon_sym_GT,
-  [344] = 3,
-    ACTIONS(102), 1,
-      anon_sym_PLUS,
-    STATE(20), 1,
-      aux_sym_chord_repeat1,
-    ACTIONS(104), 2,
-      anon_sym_EQ2,
-      anon_sym_GT,
-  [355] = 3,
+  [333] = 2,
+    ACTIONS(94), 2,
+      ts_builtin_sym_end,
+      aux_sym_source_file_token1,
+    ACTIONS(96), 5,
+      sym_comment,
+      sym__kebab_case_identifier,
+      anon_sym_palette,
+      anon_sym_config_DASHfile,
+      anon_sym_keybind,
+  [345] = 2,
+    ACTIONS(98), 2,
+      ts_builtin_sym_end,
+      aux_sym_source_file_token1,
+    ACTIONS(100), 5,
+      sym_comment,
+      sym__kebab_case_identifier,
+      anon_sym_palette,
+      anon_sym_config_DASHfile,
+      anon_sym_keybind,
+  [357] = 2,
+    ACTIONS(102), 2,
+      ts_builtin_sym_end,
+      aux_sym_source_file_token1,
+    ACTIONS(104), 5,
+      sym_comment,
+      sym__kebab_case_identifier,
+      anon_sym_palette,
+      anon_sym_config_DASHfile,
+      anon_sym_keybind,
+  [369] = 3,
     ACTIONS(108), 1,
       anon_sym_PLUS,
-    STATE(20), 1,
+    STATE(19), 1,
       aux_sym_chord_repeat1,
     ACTIONS(106), 2,
       anon_sym_EQ2,
       anon_sym_GT,
-  [366] = 1,
-    ACTIONS(111), 3,
+  [380] = 3,
+    ACTIONS(108), 1,
+      anon_sym_PLUS,
+    STATE(20), 1,
+      aux_sym_chord_repeat1,
+    ACTIONS(110), 2,
       anon_sym_EQ2,
       anon_sym_GT,
+  [391] = 3,
+    ACTIONS(114), 1,
       anon_sym_PLUS,
-  [372] = 3,
-    ACTIONS(113), 1,
-      aux_sym_source_file_token1,
-    ACTIONS(115), 1,
-      aux_sym_palette_value_token1,
-    STATE(35), 1,
-      sym_palette_value,
-  [382] = 1,
-    ACTIONS(106), 3,
+    STATE(20), 1,
+      aux_sym_chord_repeat1,
+    ACTIONS(112), 2,
       anon_sym_EQ2,
       anon_sym_GT,
-      anon_sym_PLUS,
-  [388] = 3,
+  [402] = 3,
     ACTIONS(117), 1,
       anon_sym_EQ2,
     ACTIONS(119), 1,
       anon_sym_GT,
     STATE(24), 1,
       aux_sym_keybind_trigger_repeat1,
-  [398] = 3,
-    ACTIONS(122), 1,
+  [412] = 1,
+    ACTIONS(121), 3,
       anon_sym_EQ2,
-    ACTIONS(124), 1,
       anon_sym_GT,
-    STATE(26), 1,
-      aux_sym_keybind_trigger_repeat1,
-  [408] = 3,
-    ACTIONS(124), 1,
-      anon_sym_GT,
-    ACTIONS(126), 1,
+      anon_sym_PLUS,
+  [418] = 1,
+    ACTIONS(123), 3,
       anon_sym_EQ2,
-    STATE(24), 1,
+      anon_sym_GT,
+      anon_sym_PLUS,
+  [424] = 3,
+    ACTIONS(119), 1,
+      anon_sym_GT,
+    ACTIONS(125), 1,
+      anon_sym_EQ2,
+    STATE(25), 1,
       aux_sym_keybind_trigger_repeat1,
-  [418] = 2,
-    ACTIONS(128), 1,
-      aux_sym_keybind_action_token1,
-    STATE(53), 1,
-      sym_keybind_action,
-  [425] = 2,
-    ACTIONS(130), 1,
-      aux_sym_raw_value_token1,
-    STATE(41), 1,
-      sym_raw_value,
-  [432] = 2,
+  [434] = 3,
+    ACTIONS(127), 1,
+      anon_sym_EQ2,
+    ACTIONS(129), 1,
+      anon_sym_GT,
+    STATE(25), 1,
+      aux_sym_keybind_trigger_repeat1,
+  [444] = 3,
     ACTIONS(132), 1,
       aux_sym_source_file_token1,
     ACTIONS(134), 1,
-      anon_sym_COLON,
-  [439] = 1,
-    ACTIONS(117), 2,
+      aux_sym_palette_value_token1,
+    STATE(56), 1,
+      sym_palette_value,
+  [454] = 1,
+    ACTIONS(136), 3,
       anon_sym_EQ2,
       anon_sym_GT,
-  [444] = 2,
-    ACTIONS(130), 1,
+      anon_sym_PLUS,
+  [460] = 1,
+    ACTIONS(112), 3,
+      anon_sym_EQ2,
+      anon_sym_GT,
+      anon_sym_PLUS,
+  [466] = 2,
+    ACTIONS(138), 1,
       aux_sym_raw_value_token1,
-    STATE(59), 1,
+    STATE(66), 1,
       sym_raw_value,
-  [451] = 2,
-    ACTIONS(128), 1,
-      aux_sym_keybind_action_token1,
+  [473] = 2,
+    ACTIONS(140), 1,
+      sym__snake_case_identifier,
     STATE(58), 1,
       sym_keybind_action,
-  [458] = 1,
-    ACTIONS(136), 1,
-      anon_sym_EQ,
-  [462] = 1,
-    ACTIONS(138), 1,
-      aux_sym_source_file_token1,
-  [466] = 1,
-    ACTIONS(140), 1,
-      aux_sym_source_file_token1,
-  [470] = 1,
+  [480] = 2,
     ACTIONS(142), 1,
-      aux_sym_palette_value_token2,
-  [474] = 1,
+      aux_sym_source_file_token1,
     ACTIONS(144), 1,
-      anon_sym_EQ,
-  [478] = 1,
-    ACTIONS(146), 1,
-      ts_builtin_sym_end,
-  [482] = 1,
-    ACTIONS(148), 1,
-      aux_sym_string_literal_token2,
-  [486] = 1,
-    ACTIONS(150), 1,
-      aux_sym_source_file_token1,
-  [490] = 1,
-    ACTIONS(152), 1,
-      aux_sym_source_file_token1,
-  [494] = 1,
-    ACTIONS(154), 1,
-      aux_sym_source_file_token1,
-  [498] = 1,
-    ACTIONS(156), 1,
       anon_sym_COLON,
-  [502] = 1,
-    ACTIONS(158), 1,
-      aux_sym_source_file_token1,
+  [487] = 1,
+    ACTIONS(127), 2,
+      anon_sym_EQ2,
+      anon_sym_GT,
+  [492] = 2,
+    ACTIONS(146), 1,
+      aux_sym_raw_value_token1,
+    STATE(60), 1,
+      sym_path_value,
+  [499] = 2,
+    ACTIONS(140), 1,
+      sym__snake_case_identifier,
+    STATE(65), 1,
+      sym_keybind_action,
   [506] = 1,
-    ACTIONS(160), 1,
+    ACTIONS(148), 1,
       aux_sym_source_file_token1,
   [510] = 1,
-    ACTIONS(162), 1,
-      anon_sym_EQ2,
+    ACTIONS(150), 1,
+      anon_sym_EQ,
   [514] = 1,
-    ACTIONS(164), 1,
-      aux_sym_string_literal_token1,
-  [518] = 1,
-    ACTIONS(166), 1,
+    ACTIONS(152), 1,
       aux_sym_source_file_token1,
+  [518] = 1,
+    ACTIONS(154), 1,
+      aux_sym_palette_value_token2,
   [522] = 1,
+    ACTIONS(156), 1,
+      ts_builtin_sym_end,
+  [526] = 1,
+    ACTIONS(158), 1,
+      aux_sym_string_literal_token1,
+  [530] = 1,
+    ACTIONS(160), 1,
+      anon_sym_DQUOTE,
+  [534] = 1,
+    ACTIONS(160), 1,
+      anon_sym_SQUOTE,
+  [538] = 1,
+    ACTIONS(162), 1,
+      anon_sym_EQ,
+  [542] = 1,
+    ACTIONS(164), 1,
+      sym__snake_case_identifier,
+  [546] = 1,
+    ACTIONS(166), 1,
+      aux_sym_string_literal_token2,
+  [550] = 1,
     ACTIONS(168), 1,
       aux_sym_source_file_token1,
-  [526] = 1,
+  [554] = 1,
     ACTIONS(170), 1,
       anon_sym_EQ,
-  [530] = 1,
-    ACTIONS(172), 1,
-      aux_sym_source_file_token1,
-  [534] = 1,
-    ACTIONS(174), 1,
-      anon_sym_EQ2,
-  [538] = 1,
-    ACTIONS(176), 1,
-      aux_sym_source_file_token1,
-  [542] = 1,
-    ACTIONS(178), 1,
-      anon_sym_EQ,
-  [546] = 1,
-    ACTIONS(180), 1,
-      anon_sym_EQ2,
-  [550] = 1,
-    ACTIONS(182), 1,
-      anon_sym_DQUOTE,
-  [554] = 1,
-    ACTIONS(182), 1,
-      anon_sym_SQUOTE,
   [558] = 1,
+    ACTIONS(172), 1,
+      anon_sym_COLON,
+  [562] = 1,
+    ACTIONS(174), 1,
+      anon_sym_COLON,
+  [566] = 1,
+    ACTIONS(176), 1,
+      anon_sym_EQ2,
+  [570] = 1,
+    ACTIONS(178), 1,
+      anon_sym_EQ2,
+  [574] = 1,
+    ACTIONS(180), 1,
+      aux_sym_source_file_token1,
+  [578] = 1,
+    ACTIONS(182), 1,
+      anon_sym_EQ2,
+  [582] = 1,
     ACTIONS(184), 1,
       aux_sym_source_file_token1,
-  [562] = 1,
+  [586] = 1,
     ACTIONS(186), 1,
+      aux_sym_source_file_token1,
+  [590] = 1,
+    ACTIONS(188), 1,
+      aux_sym_source_file_token1,
+  [594] = 1,
+    ACTIONS(190), 1,
+      aux_sym_source_file_token1,
+  [598] = 1,
+    ACTIONS(192), 1,
+      aux_sym_source_file_token1,
+  [602] = 1,
+    ACTIONS(194), 1,
+      anon_sym_EQ,
+  [606] = 1,
+    ACTIONS(196), 1,
+      aux_sym_source_file_token1,
+  [610] = 1,
+    ACTIONS(198), 1,
+      aux_sym_source_file_token1,
+  [614] = 1,
+    ACTIONS(200), 1,
+      aux_sym_source_file_token1,
+  [618] = 1,
+    ACTIONS(202), 1,
+      aux_sym_source_file_token1,
+  [622] = 1,
+    ACTIONS(204), 1,
+      anon_sym_EQ,
+  [626] = 1,
+    ACTIONS(206), 1,
+      aux_sym_source_file_token1,
+  [630] = 1,
+    ACTIONS(208), 1,
       aux_sym_source_file_token1,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(2)] = 0,
-  [SMALL_STATE(3)] = 38,
-  [SMALL_STATE(4)] = 72,
-  [SMALL_STATE(5)] = 95,
-  [SMALL_STATE(6)] = 129,
-  [SMALL_STATE(7)] = 146,
-  [SMALL_STATE(8)] = 178,
-  [SMALL_STATE(9)] = 210,
-  [SMALL_STATE(10)] = 231,
-  [SMALL_STATE(11)] = 249,
-  [SMALL_STATE(12)] = 261,
-  [SMALL_STATE(13)] = 273,
-  [SMALL_STATE(14)] = 285,
-  [SMALL_STATE(15)] = 297,
-  [SMALL_STATE(16)] = 309,
-  [SMALL_STATE(17)] = 321,
-  [SMALL_STATE(18)] = 333,
-  [SMALL_STATE(19)] = 344,
-  [SMALL_STATE(20)] = 355,
-  [SMALL_STATE(21)] = 366,
-  [SMALL_STATE(22)] = 372,
-  [SMALL_STATE(23)] = 382,
-  [SMALL_STATE(24)] = 388,
-  [SMALL_STATE(25)] = 398,
-  [SMALL_STATE(26)] = 408,
-  [SMALL_STATE(27)] = 418,
-  [SMALL_STATE(28)] = 425,
-  [SMALL_STATE(29)] = 432,
-  [SMALL_STATE(30)] = 439,
-  [SMALL_STATE(31)] = 444,
-  [SMALL_STATE(32)] = 451,
-  [SMALL_STATE(33)] = 458,
-  [SMALL_STATE(34)] = 462,
-  [SMALL_STATE(35)] = 466,
-  [SMALL_STATE(36)] = 470,
-  [SMALL_STATE(37)] = 474,
-  [SMALL_STATE(38)] = 478,
-  [SMALL_STATE(39)] = 482,
-  [SMALL_STATE(40)] = 486,
-  [SMALL_STATE(41)] = 490,
-  [SMALL_STATE(42)] = 494,
-  [SMALL_STATE(43)] = 498,
-  [SMALL_STATE(44)] = 502,
-  [SMALL_STATE(45)] = 506,
-  [SMALL_STATE(46)] = 510,
-  [SMALL_STATE(47)] = 514,
-  [SMALL_STATE(48)] = 518,
-  [SMALL_STATE(49)] = 522,
-  [SMALL_STATE(50)] = 526,
-  [SMALL_STATE(51)] = 530,
-  [SMALL_STATE(52)] = 534,
-  [SMALL_STATE(53)] = 538,
-  [SMALL_STATE(54)] = 542,
-  [SMALL_STATE(55)] = 546,
-  [SMALL_STATE(56)] = 550,
-  [SMALL_STATE(57)] = 554,
-  [SMALL_STATE(58)] = 558,
-  [SMALL_STATE(59)] = 562,
+  [SMALL_STATE(3)] = 54,
+  [SMALL_STATE(4)] = 92,
+  [SMALL_STATE(5)] = 116,
+  [SMALL_STATE(6)] = 150,
+  [SMALL_STATE(7)] = 168,
+  [SMALL_STATE(8)] = 203,
+  [SMALL_STATE(9)] = 238,
+  [SMALL_STATE(10)] = 263,
+  [SMALL_STATE(11)] = 285,
+  [SMALL_STATE(12)] = 297,
+  [SMALL_STATE(13)] = 309,
+  [SMALL_STATE(14)] = 321,
+  [SMALL_STATE(15)] = 333,
+  [SMALL_STATE(16)] = 345,
+  [SMALL_STATE(17)] = 357,
+  [SMALL_STATE(18)] = 369,
+  [SMALL_STATE(19)] = 380,
+  [SMALL_STATE(20)] = 391,
+  [SMALL_STATE(21)] = 402,
+  [SMALL_STATE(22)] = 412,
+  [SMALL_STATE(23)] = 418,
+  [SMALL_STATE(24)] = 424,
+  [SMALL_STATE(25)] = 434,
+  [SMALL_STATE(26)] = 444,
+  [SMALL_STATE(27)] = 454,
+  [SMALL_STATE(28)] = 460,
+  [SMALL_STATE(29)] = 466,
+  [SMALL_STATE(30)] = 473,
+  [SMALL_STATE(31)] = 480,
+  [SMALL_STATE(32)] = 487,
+  [SMALL_STATE(33)] = 492,
+  [SMALL_STATE(34)] = 499,
+  [SMALL_STATE(35)] = 506,
+  [SMALL_STATE(36)] = 510,
+  [SMALL_STATE(37)] = 514,
+  [SMALL_STATE(38)] = 518,
+  [SMALL_STATE(39)] = 522,
+  [SMALL_STATE(40)] = 526,
+  [SMALL_STATE(41)] = 530,
+  [SMALL_STATE(42)] = 534,
+  [SMALL_STATE(43)] = 538,
+  [SMALL_STATE(44)] = 542,
+  [SMALL_STATE(45)] = 546,
+  [SMALL_STATE(46)] = 550,
+  [SMALL_STATE(47)] = 554,
+  [SMALL_STATE(48)] = 558,
+  [SMALL_STATE(49)] = 562,
+  [SMALL_STATE(50)] = 566,
+  [SMALL_STATE(51)] = 570,
+  [SMALL_STATE(52)] = 574,
+  [SMALL_STATE(53)] = 578,
+  [SMALL_STATE(54)] = 582,
+  [SMALL_STATE(55)] = 586,
+  [SMALL_STATE(56)] = 590,
+  [SMALL_STATE(57)] = 594,
+  [SMALL_STATE(58)] = 598,
+  [SMALL_STATE(59)] = 602,
+  [SMALL_STATE(60)] = 606,
+  [SMALL_STATE(61)] = 610,
+  [SMALL_STATE(62)] = 614,
+  [SMALL_STATE(63)] = 618,
+  [SMALL_STATE(64)] = 622,
+  [SMALL_STATE(65)] = 626,
+  [SMALL_STATE(66)] = 630,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 0, 0, 0),
-  [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
-  [7] = {.entry = {.count = 1, .reusable = false}}, SHIFT(7),
-  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(33),
-  [11] = {.entry = {.count = 1, .reusable = false}}, SHIFT(54),
-  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(50),
-  [15] = {.entry = {.count = 1, .reusable = false}}, SHIFT(37),
-  [17] = {.entry = {.count = 1, .reusable = false}}, SHIFT(43),
-  [19] = {.entry = {.count = 1, .reusable = false}}, SHIFT(21),
-  [21] = {.entry = {.count = 1, .reusable = false}}, SHIFT(18),
-  [23] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_keybind_value_repeat1, 2, 0, 0), SHIFT_REPEAT(43),
-  [26] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_keybind_value_repeat1, 2, 0, 0),
-  [28] = {.entry = {.count = 1, .reusable = false}}, SHIFT(12),
-  [30] = {.entry = {.count = 1, .reusable = false}}, SHIFT(40),
-  [32] = {.entry = {.count = 1, .reusable = false}}, SHIFT(42),
-  [34] = {.entry = {.count = 1, .reusable = false}}, SHIFT(44),
-  [36] = {.entry = {.count = 1, .reusable = false}}, SHIFT(47),
-  [38] = {.entry = {.count = 1, .reusable = false}}, SHIFT(39),
-  [40] = {.entry = {.count = 1, .reusable = false}}, SHIFT(34),
-  [42] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keybind_modifier, 2, 0, 3),
-  [44] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 1, 0, 0),
-  [46] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
-  [48] = {.entry = {.count = 1, .reusable = false}}, SHIFT(8),
-  [50] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0),
-  [52] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(8),
-  [55] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(8),
-  [58] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(33),
-  [61] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(54),
-  [64] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(50),
-  [67] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(37),
-  [70] = {.entry = {.count = 1, .reusable = false}}, SHIFT(23),
-  [72] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_directive, 1, 0, 0),
-  [74] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_directive, 1, 0, 0),
-  [76] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_basic_directive, 3, 0, 1),
-  [78] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_basic_directive, 3, 0, 1),
-  [80] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_palette_directive, 3, 0, 1),
-  [82] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_palette_directive, 3, 0, 1),
-  [84] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_palette_directive, 4, 0, 2),
-  [86] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_palette_directive, 4, 0, 2),
-  [88] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keybind_directive, 4, 0, 2),
-  [90] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keybind_directive, 4, 0, 2),
-  [92] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_basic_directive, 4, 0, 2),
-  [94] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_basic_directive, 4, 0, 2),
-  [96] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_config_file_directive, 4, 0, 2),
-  [98] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_config_file_directive, 4, 0, 2),
-  [100] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_chord, 1, 0, 0),
-  [102] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
-  [104] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_chord, 2, 0, 0),
-  [106] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_chord_repeat1, 2, 0, 0),
-  [108] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_chord_repeat1, 2, 0, 0), SHIFT_REPEAT(10),
-  [111] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_key_modifier, 1, 0, 0),
-  [113] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
-  [115] = {.entry = {.count = 1, .reusable = false}}, SHIFT(55),
-  [117] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_keybind_trigger_repeat1, 2, 0, 0),
-  [119] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_keybind_trigger_repeat1, 2, 0, 0), SHIFT_REPEAT(9),
-  [122] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keybind_trigger, 1, 0, 0),
-  [124] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
-  [126] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keybind_trigger, 2, 0, 0),
-  [128] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
-  [130] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
-  [132] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keybind_action, 1, 0, 4),
-  [134] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
-  [136] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
-  [138] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_raw_value, 1, 0, 0),
-  [140] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
-  [142] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
-  [144] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
-  [146] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [148] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
-  [150] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_boolean_literal, 1, 0, 0),
+  [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
+  [7] = {.entry = {.count = 1, .reusable = false}}, SHIFT(8),
+  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(59),
+  [11] = {.entry = {.count = 1, .reusable = false}}, SHIFT(47),
+  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(64),
+  [15] = {.entry = {.count = 1, .reusable = false}}, SHIFT(36),
+  [17] = {.entry = {.count = 1, .reusable = false}}, SHIFT(22),
+  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
+  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
+  [23] = {.entry = {.count = 1, .reusable = false}}, SHIFT(46),
+  [25] = {.entry = {.count = 1, .reusable = false}}, SHIFT(48),
+  [27] = {.entry = {.count = 1, .reusable = false}}, SHIFT(49),
+  [29] = {.entry = {.count = 1, .reusable = false}}, SHIFT(23),
+  [31] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_keybind_value_repeat1, 2, 0, 0),
+  [33] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_keybind_value_repeat1, 2, 0, 0), SHIFT_REPEAT(48),
+  [36] = {.entry = {.count = 1, .reusable = false}}, SHIFT(15),
+  [38] = {.entry = {.count = 1, .reusable = false}}, SHIFT(61),
+  [40] = {.entry = {.count = 1, .reusable = false}}, SHIFT(62),
+  [42] = {.entry = {.count = 1, .reusable = false}}, SHIFT(40),
+  [44] = {.entry = {.count = 1, .reusable = false}}, SHIFT(45),
+  [46] = {.entry = {.count = 1, .reusable = false}}, SHIFT(63),
+  [48] = {.entry = {.count = 1, .reusable = false}}, SHIFT(35),
+  [50] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keybind_modifier, 2, 0, 5),
+  [52] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0),
+  [54] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(7),
+  [57] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(7),
+  [60] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(59),
+  [63] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(47),
+  [66] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(64),
+  [69] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(36),
+  [72] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 1, 0, 0),
+  [74] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
+  [76] = {.entry = {.count = 1, .reusable = false}}, SHIFT(7),
+  [78] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_directive, 1, 0, 0),
+  [80] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_directive, 1, 0, 0),
+  [82] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_palette_directive, 4, 0, 4),
+  [84] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_palette_directive, 4, 0, 4),
+  [86] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_palette_directive, 3, 0, 1),
+  [88] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_palette_directive, 3, 0, 1),
+  [90] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_config_file_directive, 4, 0, 4),
+  [92] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_config_file_directive, 4, 0, 4),
+  [94] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_basic_directive, 3, 0, 1),
+  [96] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_basic_directive, 3, 0, 1),
+  [98] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keybind_directive, 4, 0, 4),
+  [100] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keybind_directive, 4, 0, 4),
+  [102] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_basic_directive, 4, 0, 4),
+  [104] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_basic_directive, 4, 0, 4),
+  [106] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_chord, 1, 0, 0),
+  [108] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
+  [110] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_chord, 2, 0, 0),
+  [112] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_chord_repeat1, 2, 0, 0),
+  [114] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_chord_repeat1, 2, 0, 0), SHIFT_REPEAT(10),
+  [117] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keybind_trigger, 1, 0, 0),
+  [119] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
+  [121] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_key, 1, 0, 2),
+  [123] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_key_modifier, 1, 0, 0),
+  [125] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keybind_trigger, 2, 0, 0),
+  [127] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_keybind_trigger_repeat1, 2, 0, 0),
+  [129] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_keybind_trigger_repeat1, 2, 0, 0), SHIFT_REPEAT(9),
+  [132] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
+  [134] = {.entry = {.count = 1, .reusable = false}}, SHIFT(50),
+  [136] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_key, 3, 0, 6),
+  [138] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
+  [140] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
+  [142] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keybind_action, 1, 0, 7),
+  [144] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
+  [146] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
+  [148] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_raw_value, 1, 0, 0),
+  [150] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
   [152] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
-  [154] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_value, 1, 0, 0),
-  [156] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
-  [158] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_adjustment, 1, 0, 0),
-  [160] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
-  [162] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
-  [164] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
-  [166] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string_literal, 3, 0, 0),
-  [168] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_palette_value, 3, 0, 0),
-  [170] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
-  [172] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
-  [174] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
-  [176] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keybind_value, 3, 0, 5),
-  [178] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
-  [180] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
-  [182] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
-  [184] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keybind_value, 4, 0, 6),
-  [186] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keybind_action, 3, 0, 7),
+  [154] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
+  [156] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [158] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
+  [160] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
+  [162] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
+  [164] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
+  [166] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
+  [168] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__keybind_value, 1, 0, 3),
+  [170] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
+  [172] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
+  [174] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
+  [176] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
+  [178] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
+  [180] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
+  [182] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
+  [184] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_palette_value, 3, 0, 0),
+  [186] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string_literal, 3, 0, 0),
+  [188] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
+  [190] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_path_value, 1, 0, 0),
+  [192] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keybind_value, 3, 0, 8),
+  [194] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 1, 0, 0),
+  [196] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
+  [198] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_boolean_literal, 1, 0, 0),
+  [200] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_value, 1, 0, 0),
+  [202] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_adjustment, 1, 0, 0),
+  [204] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
+  [206] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keybind_value, 4, 0, 9),
+  [208] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keybind_action, 3, 0, 10),
 };
 
 #ifdef __cplusplus

--- a/src/parser.c
+++ b/src/parser.c
@@ -4,16 +4,24 @@
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
+#ifdef _MSC_VER
+#pragma optimize("", off)
+#elif defined(__clang__)
+#pragma clang optimize off
+#elif defined(__GNUC__)
+#pragma GCC optimize ("O0")
+#endif
+
 #define LANGUAGE_VERSION 14
-#define STATE_COUNT 67
+#define STATE_COUNT 68
 #define LARGE_STATE_COUNT 2
-#define SYMBOL_COUNT 67
+#define SYMBOL_COUNT 69
 #define ALIAS_COUNT 2
-#define TOKEN_COUNT 41
+#define TOKEN_COUNT 42
 #define EXTERNAL_TOKEN_COUNT 0
-#define FIELD_COUNT 8
+#define FIELD_COUNT 9
 #define MAX_ALIAS_SEQUENCE_LENGTH 4
-#define PRODUCTION_ID_COUNT 11
+#define PRODUCTION_ID_COUNT 12
 
 enum ts_symbol_identifiers {
   aux_sym_source_file_token1 = 1,
@@ -44,7 +52,7 @@ enum ts_symbol_identifiers {
   anon_sym_local = 26,
   anon_sym_unconsumed = 27,
   anon_sym_COLON = 28,
-  sym_key_prefix = 29,
+  anon_sym_physical = 29,
   anon_sym_GT = 30,
   anon_sym_PLUS = 31,
   anon_sym_shift = 32,
@@ -56,34 +64,36 @@ enum ts_symbol_identifiers {
   anon_sym_super = 38,
   anon_sym_cmd = 39,
   anon_sym_command = 40,
-  sym_source_file = 41,
-  sym_directive = 42,
-  sym_basic_directive = 43,
-  sym_property = 44,
-  sym_value = 45,
-  sym_boolean_literal = 46,
-  sym_adjustment = 47,
-  sym_string_literal = 48,
-  sym_raw_value = 49,
-  sym_palette_directive = 50,
-  sym_palette_value = 51,
-  sym_config_file_directive = 52,
-  sym_path_value = 53,
-  sym_keybind_directive = 54,
-  sym__keybind_value = 55,
-  sym_keybind_value = 56,
-  sym_keybind_modifier = 57,
-  sym_keybind_trigger = 58,
-  sym_chord = 59,
-  sym_key_modifier = 60,
-  sym_key = 61,
-  sym_keybind_action = 62,
-  aux_sym_source_file_repeat1 = 63,
-  aux_sym_keybind_value_repeat1 = 64,
-  aux_sym_keybind_trigger_repeat1 = 65,
-  aux_sym_chord_repeat1 = 66,
-  alias_sym_action_argument = 67,
-  alias_sym_action_name = 68,
+  aux_sym_key_token1 = 41,
+  sym_source_file = 42,
+  sym_directive = 43,
+  sym_basic_directive = 44,
+  sym_property = 45,
+  sym_value = 46,
+  sym_boolean_literal = 47,
+  sym_adjustment = 48,
+  sym_string_literal = 49,
+  sym_raw_value = 50,
+  sym_palette_directive = 51,
+  sym_palette_value = 52,
+  sym_config_file_directive = 53,
+  sym_path_value = 54,
+  sym_keybind_directive = 55,
+  sym__keybind_value = 56,
+  sym_keybind_value = 57,
+  sym_keybind_modifier = 58,
+  sym_key_prefix = 59,
+  sym_keybind_trigger = 60,
+  sym_chord = 61,
+  sym_key_modifier = 62,
+  sym_key = 63,
+  sym_keybind_action = 64,
+  aux_sym_source_file_repeat1 = 65,
+  aux_sym_keybind_value_repeat1 = 66,
+  aux_sym_keybind_trigger_repeat1 = 67,
+  aux_sym_chord_repeat1 = 68,
+  alias_sym_action_argument = 69,
+  alias_sym_action_name = 70,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -116,7 +126,7 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_local] = "local",
   [anon_sym_unconsumed] = "unconsumed",
   [anon_sym_COLON] = ":",
-  [sym_key_prefix] = "key_prefix",
+  [anon_sym_physical] = "physical",
   [anon_sym_GT] = ">",
   [anon_sym_PLUS] = "+",
   [anon_sym_shift] = "shift",
@@ -128,6 +138,7 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_super] = "super",
   [anon_sym_cmd] = "cmd",
   [anon_sym_command] = "command",
+  [aux_sym_key_token1] = "key_token1",
   [sym_source_file] = "source_file",
   [sym_directive] = "directive",
   [sym_basic_directive] = "basic_directive",
@@ -145,6 +156,7 @@ static const char * const ts_symbol_names[] = {
   [sym__keybind_value] = "_keybind_value",
   [sym_keybind_value] = "keybind_value",
   [sym_keybind_modifier] = "keybind_modifier",
+  [sym_key_prefix] = "key_prefix",
   [sym_keybind_trigger] = "keybind_trigger",
   [sym_chord] = "chord",
   [sym_key_modifier] = "key_modifier",
@@ -188,7 +200,7 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_local] = anon_sym_local,
   [anon_sym_unconsumed] = anon_sym_unconsumed,
   [anon_sym_COLON] = anon_sym_COLON,
-  [sym_key_prefix] = sym_key_prefix,
+  [anon_sym_physical] = anon_sym_physical,
   [anon_sym_GT] = anon_sym_GT,
   [anon_sym_PLUS] = anon_sym_PLUS,
   [anon_sym_shift] = anon_sym_shift,
@@ -200,6 +212,7 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_super] = anon_sym_super,
   [anon_sym_cmd] = anon_sym_cmd,
   [anon_sym_command] = anon_sym_command,
+  [aux_sym_key_token1] = aux_sym_key_token1,
   [sym_source_file] = sym_source_file,
   [sym_directive] = sym_directive,
   [sym_basic_directive] = sym_basic_directive,
@@ -217,6 +230,7 @@ static const TSSymbol ts_symbol_map[] = {
   [sym__keybind_value] = sym__keybind_value,
   [sym_keybind_value] = sym_keybind_value,
   [sym_keybind_modifier] = sym_keybind_modifier,
+  [sym_key_prefix] = sym_key_prefix,
   [sym_keybind_trigger] = sym_keybind_trigger,
   [sym_chord] = sym_chord,
   [sym_key_modifier] = sym_key_modifier,
@@ -347,9 +361,9 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
-  [sym_key_prefix] = {
+  [anon_sym_physical] = {
     .visible = true,
-    .named = true,
+    .named = false,
   },
   [anon_sym_GT] = {
     .visible = true,
@@ -393,6 +407,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
   },
   [anon_sym_command] = {
     .visible = true,
+    .named = false,
+  },
+  [aux_sym_key_token1] = {
+    .visible = false,
     .named = false,
   },
   [sym_source_file] = {
@@ -463,6 +481,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
+  [sym_key_prefix] = {
+    .visible = true,
+    .named = true,
+  },
   [sym_keybind_trigger] = {
     .visible = true,
     .named = true,
@@ -515,9 +537,10 @@ enum ts_field_identifiers {
   field_argument = 3,
   field_bind = 4,
   field_modifier = 5,
-  field_property = 6,
-  field_trigger = 7,
-  field_value = 8,
+  field_prefix_name = 6,
+  field_property = 7,
+  field_trigger = 8,
+  field_value = 9,
 };
 
 static const char * const ts_field_names[] = {
@@ -527,6 +550,7 @@ static const char * const ts_field_names[] = {
   [field_argument] = "argument",
   [field_bind] = "bind",
   [field_modifier] = "modifier",
+  [field_prefix_name] = "prefix_name",
   [field_property] = "property",
   [field_trigger] = "trigger",
   [field_value] = "value",
@@ -539,9 +563,10 @@ static const TSFieldMapSlice ts_field_map_slices[PRODUCTION_ID_COUNT] = {
   [5] = {.index = 4, .length = 1},
   [6] = {.index = 5, .length = 1},
   [7] = {.index = 6, .length = 1},
-  [8] = {.index = 7, .length = 2},
-  [9] = {.index = 9, .length = 2},
-  [10] = {.index = 11, .length = 2},
+  [8] = {.index = 7, .length = 1},
+  [9] = {.index = 8, .length = 2},
+  [10] = {.index = 10, .length = 2},
+  [11] = {.index = 12, .length = 2},
 };
 
 static const TSFieldMapEntry ts_field_map_entries[] = {
@@ -555,16 +580,18 @@ static const TSFieldMapEntry ts_field_map_entries[] = {
   [4] =
     {field_modifier, 0},
   [5] =
-    {field_bind, 2},
+    {field_prefix_name, 0},
   [6] =
-    {field_action_name, 0},
+    {field_bind, 1},
   [7] =
+    {field_action_name, 0},
+  [8] =
     {field_action, 2},
     {field_trigger, 0},
-  [9] =
+  [10] =
     {field_action, 3},
     {field_trigger, 1},
-  [11] =
+  [12] =
     {field_action_name, 0},
     {field_argument, 2},
 };
@@ -574,10 +601,10 @@ static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE
   [3] = {
     [0] = sym_value,
   },
-  [7] = {
+  [8] = {
     [0] = alias_sym_action_name,
   },
-  [10] = {
+  [11] = {
     [0] = alias_sym_action_name,
     [2] = alias_sym_action_argument,
   },
@@ -661,6 +688,7 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [64] = 64,
   [65] = 65,
   [66] = 66,
+  [67] = 67,
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -670,47 +698,46 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 0:
       if (eof) ADVANCE(32);
       ADVANCE_MAP(
-        '"', 219,
+        '"', 239,
         '#', 26,
-        '\'', 223,
-        '+', 278,
-        '-', 13,
-        ':', 273,
-        '=', 258,
-        '>', 276,
-        '_', 198,
-        'a', 69,
-        'c', 77,
+        '\'', 243,
+        '+', 298,
+        ':', 294,
+        '=', 276,
+        '>', 297,
+        '_', 208,
+        'a', 70,
+        'c', 80,
         'f', 37,
-        'g', 78,
-        'k', 53,
-        'l', 88,
-        'o', 93,
+        'g', 82,
+        'k', 54,
+        'l', 92,
+        'o', 97,
         'p', 38,
-        's', 64,
-        't', 95,
-        'u', 85,
-        'b', 115,
-        'd', 115,
-        'e', 115,
+        's', 65,
+        't', 99,
+        'u', 89,
+        'b', 123,
+        'd', 123,
+        'e', 123,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(31);
       if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(24);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(211);
-      if (('h' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(236);
+      if (('h' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 1:
       if (lookahead == '\n') ADVANCE(33);
       if (lookahead == '\r') ADVANCE(1);
       if (lookahead == '#') ADVANCE(3);
-      if (lookahead == 'c') ADVANCE(133);
-      if (lookahead == 'k') ADVANCE(121);
-      if (lookahead == 'p') ADVANCE(117);
+      if (lookahead == 'c') ADVANCE(142);
+      if (lookahead == 'k') ADVANCE(130);
+      if (lookahead == 'p') ADVANCE(126);
       if (('\t' <= lookahead && lookahead <= '\f') ||
           lookahead == ' ') SKIP(1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(257);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(275);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
       END_STATE();
     case 2:
       if (lookahead == '\n') ADVANCE(35);
@@ -724,133 +751,144 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ADVANCE_MAP(
         '\n', 34,
         '\r', 4,
-        '"', 220,
-        '#', 251,
-        '\'', 224,
-        'f', 235,
-        't', 239,
-        '+', 243,
-        '-', 243,
-        '\t', 234,
-        0x0b, 234,
-        '\f', 234,
-        ' ', 234,
+        '"', 240,
+        '#', 269,
+        '\'', 244,
+        'f', 253,
+        't', 257,
+        '+', 261,
+        '-', 261,
+        '\t', 252,
+        0x0b, 252,
+        '\f', 252,
+        ' ', 252,
       );
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(217);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(225);
       if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'e')) ADVANCE(250);
-      if (lookahead != 0) ADVANCE(252);
+          ('a' <= lookahead && lookahead <= 'e')) ADVANCE(268);
+      if (lookahead != 0) ADVANCE(270);
       END_STATE();
     case 5:
       ADVANCE_MAP(
-        '"', 219,
-        '\'', 223,
-        '+', 277,
-        '=', 258,
-        '>', 276,
-        'a', 160,
-        'c', 161,
-        'g', 168,
-        'l', 178,
-        'o', 183,
-        'p', 156,
-        's', 157,
-        'u', 176,
+        '"', 239,
+        '\'', 243,
+        'a', 169,
+        'c', 170,
+        'g', 177,
+        'l', 187,
+        'o', 192,
+        'p', 165,
+        's', 166,
+        'u', 185,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(6);
+          lookahead == ' ') ADVANCE(318);
       if (lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(208);
+      if (lookahead != 0 &&
+          lookahead != ':' &&
+          lookahead != '=' &&
+          lookahead != '>') ADVANCE(317);
       END_STATE();
     case 6:
-      ADVANCE_MAP(
-        '"', 219,
-        '\'', 223,
-        '+', 277,
-        '>', 276,
-        'a', 160,
-        'c', 161,
-        'g', 168,
-        'l', 178,
-        'o', 183,
-        'p', 156,
-        's', 157,
-        'u', 176,
-      );
+      if (lookahead == '#') ADVANCE(26);
+      if (lookahead == '=') ADVANCE(36);
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(6);
-      if (lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(198);
-      END_STATE();
-    case 7:
-      if (lookahead == '#') ADVANCE(27);
+          lookahead == ' ') SKIP(9);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(25);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(24);
       END_STATE();
-    case 8:
-      ADVANCE_MAP(
-        '=', 36,
-        'a', 160,
-        'c', 170,
-        'g', 168,
-        'l', 178,
-        'o', 183,
-        'p', 156,
-        's', 157,
-        'u', 176,
-      );
+    case 7:
+      if (lookahead == '+') ADVANCE(298);
+      if (lookahead == '=') ADVANCE(276);
+      if (lookahead == '>') ADVANCE(297);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(8);
       if (lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
+      END_STATE();
+    case 8:
+      if (lookahead == '+') ADVANCE(298);
+      if (lookahead == '>') ADVANCE(297);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') SKIP(8);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 9:
-      if (lookahead == 'a') ADVANCE(169);
-      if (lookahead == 'c') ADVANCE(170);
-      if (lookahead == 'o') ADVANCE(183);
-      if (lookahead == 'p') ADVANCE(156);
-      if (lookahead == 's') ADVANCE(157);
+      if (lookahead == '=') ADVANCE(36);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(9);
-      if (lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(198);
       END_STATE();
     case 10:
-      if (lookahead == 'f') ADVANCE(126);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      ADVANCE_MAP(
+        'a', 169,
+        'c', 179,
+        'g', 177,
+        'l', 187,
+        'o', 192,
+        'p', 165,
+        's', 166,
+        'u', 185,
+      );
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(319);
+      if (lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(208);
+      if (lookahead != 0 &&
+          lookahead != ':' &&
+          lookahead != '=' &&
+          lookahead != '>') ADVANCE(317);
       END_STATE();
     case 11:
-      if (lookahead == '\n' ||
-          lookahead == '\r') SKIP(11);
-      if (('\t' <= lookahead && lookahead <= '\f') ||
-          lookahead == ' ') ADVANCE(242);
-      if (lookahead != 0) ADVANCE(252);
+      if (lookahead == 'a') ADVANCE(178);
+      if (lookahead == 'c') ADVANCE(179);
+      if (lookahead == 'o') ADVANCE(192);
+      if (lookahead == 'p') ADVANCE(165);
+      if (lookahead == 's') ADVANCE(166);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(320);
+      if (lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(208);
+      if (lookahead != 0 &&
+          lookahead != ':' &&
+          lookahead != '=' &&
+          lookahead != '>') ADVANCE(317);
       END_STATE();
     case 12:
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(12);
-      if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      if (lookahead == 'f') ADVANCE(135);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
       END_STATE();
     case 13:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(230);
+      if (lookahead == '\n' ||
+          lookahead == '\r') SKIP(13);
+      if (('\t' <= lookahead && lookahead <= '\f') ||
+          lookahead == ' ') ADVANCE(260);
+      if (lookahead != 0) ADVANCE(270);
       END_STATE();
     case 14:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(212);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(321);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
+      if (lookahead != 0 &&
+          lookahead != ':' &&
+          lookahead != '=' &&
+          lookahead != '>') ADVANCE(317);
       END_STATE();
     case 15:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(231);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(238);
       END_STATE();
     case 16:
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(227);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(277);
       END_STATE();
     case 17:
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(259);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(247);
       END_STATE();
     case 18:
       if (('0' <= lookahead && lookahead <= '9') ||
@@ -903,7 +941,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(25);
       END_STATE();
     case 28:
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
       END_STATE();
     case 29:
       if (eof) ADVANCE(32);
@@ -911,61 +949,60 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         '\n', 33,
         '\r', 1,
         '#', 3,
-        ':', 273,
-        '=', 258,
-        'c', 133,
-        'k', 121,
-        'p', 117,
+        ':', 294,
+        '=', 276,
+        'c', 142,
+        'k', 130,
+        'p', 126,
       );
       if (('\t' <= lookahead && lookahead <= '\f') ||
           lookahead == ' ') SKIP(30);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(257);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(275);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
       END_STATE();
     case 30:
       if (eof) ADVANCE(32);
       if (lookahead == '\n') ADVANCE(33);
       if (lookahead == '\r') ADVANCE(1);
       if (lookahead == '#') ADVANCE(3);
-      if (lookahead == 'c') ADVANCE(133);
-      if (lookahead == 'k') ADVANCE(121);
-      if (lookahead == 'p') ADVANCE(117);
+      if (lookahead == 'c') ADVANCE(142);
+      if (lookahead == 'k') ADVANCE(130);
+      if (lookahead == 'p') ADVANCE(126);
       if (('\t' <= lookahead && lookahead <= '\f') ||
           lookahead == ' ') SKIP(30);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(257);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(275);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
       END_STATE();
     case 31:
       if (eof) ADVANCE(32);
       ADVANCE_MAP(
-        '"', 219,
-        '#', 26,
-        '\'', 223,
-        '+', 278,
-        '-', 13,
+        '"', 239,
+        '#', 27,
+        '\'', 243,
+        '+', 298,
         '=', 36,
-        '>', 276,
-        '_', 198,
-        'a', 69,
-        'c', 77,
-        'f', 37,
-        'g', 78,
-        'k', 53,
-        'l', 88,
-        'o', 93,
+        '>', 297,
+        '_', 208,
+        'a', 71,
+        'c', 81,
+        'f', 44,
+        'g', 82,
+        'k', 54,
+        'l', 92,
+        'o', 97,
         'p', 38,
-        's', 64,
-        't', 95,
-        'u', 85,
-        'b', 115,
-        'd', 115,
-        'e', 115,
+        's', 65,
+        't', 99,
+        'u', 89,
+        'b', 124,
+        'd', 124,
+        'e', 124,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(31);
-      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(24);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(211);
-      if (('h' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(25);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(237);
+      if (('h' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 32:
       ACCEPT_TOKEN(ts_builtin_sym_end);
@@ -979,13 +1016,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ACCEPT_TOKEN(aux_sym_source_file_token1);
       if (lookahead == '\n') ADVANCE(34);
       if (lookahead == '\r') ADVANCE(4);
-      if (lookahead == '#') ADVANCE(251);
-      if (lookahead == 'f') ADVANCE(235);
       if (('\t' <= lookahead && lookahead <= '\f') ||
-          lookahead == ' ') ADVANCE(234);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(217);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'e')) ADVANCE(250);
+          lookahead == ' ') ADVANCE(252);
       END_STATE();
     case 35:
       ACCEPT_TOKEN(sym_comment);
@@ -996,1879 +1028,2112 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 37:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'a') ADVANCE(71);
-      if (('b' <= lookahead && lookahead <= 'f')) ADVANCE(114);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'a') ADVANCE(73);
+      if (('b' <= lookahead && lookahead <= 'f')) ADVANCE(121);
       if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(22);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(202);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(214);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 38:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'a') ADVANCE(79);
-      if (lookahead == 'h') ADVANCE(109);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('b' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'a') ADVANCE(83);
+      if (lookahead == 'h') ADVANCE(113);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('b' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 39:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'a') ADVANCE(96);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('b' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'a') ADVANCE(100);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('b' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 40:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'a') ADVANCE(84);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('b' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'a') ADVANCE(88);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('b' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 41:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'a') ADVANCE(73);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('b' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'a') ADVANCE(76);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('b' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 42:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'a') ADVANCE(74);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('b' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'a') ADVANCE(77);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('b' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 43:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'a') ADVANCE(76);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('b' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'a') ADVANCE(79);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('b' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 44:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'b') ADVANCE(67);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'a') ADVANCE(74);
+      if (('b' <= lookahead && lookahead <= 'f')) ADVANCE(122);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(23);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(215);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 45:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'b') ADVANCE(42);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'b') ADVANCE(68);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 46:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'c') ADVANCE(41);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'b') ADVANCE(42);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 47:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'c') ADVANCE(90);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'c') ADVANCE(41);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 48:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'c') ADVANCE(43);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'c') ADVANCE(94);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 49:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'd') ADVANCE(293);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'c') ADVANCE(43);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 50:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'd') ADVANCE(295);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'd') ADVANCE(313);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 51:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'd') ADVANCE(261);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'd') ADVANCE(315);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 52:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'd') ADVANCE(271);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'd') ADVANCE(282);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 53:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'e') ADVANCE(110);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'd') ADVANCE(292);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 54:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'e') ADVANCE(39);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'e') ADVANCE(114);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 55:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'e') ADVANCE(203);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'e') ADVANCE(39);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 56:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'e') ADVANCE(205);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'e') ADVANCE(216);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 57:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'e') ADVANCE(253);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'e') ADVANCE(218);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 58:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'e') ADVANCE(105);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'e') ADVANCE(271);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 59:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'e') ADVANCE(52);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'e') ADVANCE(109);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 60:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'e') ADVANCE(97);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'e') ADVANCE(53);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 61:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'f') ADVANCE(66);
-      if (lookahead == 't') ADVANCE(99);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'e') ADVANCE(101);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 62:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'f') ADVANCE(104);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'f') ADVANCE(67);
+      if (lookahead == 't') ADVANCE(103);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 63:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'g') ADVANCE(138);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'f') ADVANCE(108);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 64:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'h') ADVANCE(65);
-      if (lookahead == 'u') ADVANCE(94);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'g') ADVANCE(147);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 65:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'i') ADVANCE(62);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'h') ADVANCE(66);
+      if (lookahead == 'u') ADVANCE(98);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 66:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
+      if (lookahead == '_') ADVANCE(208);
       if (lookahead == 'i') ADVANCE(63);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 67:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'i') ADVANCE(86);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'i') ADVANCE(64);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 68:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'i') ADVANCE(48);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'i') ADVANCE(90);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 69:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'l') ADVANCE(70);
-      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(22);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(114);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(202);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'i') ADVANCE(49);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 70:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'l') ADVANCE(265);
-      if (lookahead == 't') ADVANCE(285);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'l') ADVANCE(72);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(22);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(121);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(214);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 71:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'l') ADVANCE(102);
-      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(20);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(113);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(200);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'l') ADVANCE(72);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(23);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(122);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(215);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 72:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'l') ADVANCE(281);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'l') ADVANCE(286);
+      if (lookahead == 't') ADVANCE(305);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 73:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'l') ADVANCE(269);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'l') ADVANCE(106);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(20);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(119);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(210);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 74:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'l') ADVANCE(267);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'l') ADVANCE(106);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(21);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(120);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(212);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 75:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'l') ADVANCE(283);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'l') ADVANCE(301);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 76:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'l') ADVANCE(274);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'l') ADVANCE(290);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 77:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'l') ADVANCE(54);
-      if (lookahead == 'm') ADVANCE(49);
-      if (lookahead == 'o') ADVANCE(80);
-      if (lookahead == 't') ADVANCE(98);
-      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(22);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(114);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(202);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'l') ADVANCE(288);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 78:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'l') ADVANCE(89);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'l') ADVANCE(303);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 79:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'l') ADVANCE(58);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'l') ADVANCE(295);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 80:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'm') ADVANCE(81);
-      if (lookahead == 'n') ADVANCE(61);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'l') ADVANCE(55);
+      if (lookahead == 'm') ADVANCE(50);
+      if (lookahead == 'o') ADVANCE(84);
+      if (lookahead == 't') ADVANCE(102);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(22);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(121);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(214);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 81:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'm') ADVANCE(40);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'l') ADVANCE(55);
+      if (lookahead == 'm') ADVANCE(50);
+      if (lookahead == 'o') ADVANCE(84);
+      if (lookahead == 't') ADVANCE(102);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(23);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(122);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(215);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 82:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'm') ADVANCE(59);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'l') ADVANCE(93);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 83:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'n') ADVANCE(287);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'l') ADVANCE(59);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 84:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'n') ADVANCE(50);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'm') ADVANCE(85);
+      if (lookahead == 'n') ADVANCE(62);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 85:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'n') ADVANCE(47);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'm') ADVANCE(40);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 86:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'n') ADVANCE(51);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'm') ADVANCE(60);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 87:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'n') ADVANCE(100);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'n') ADVANCE(307);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 88:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'o') ADVANCE(46);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'n') ADVANCE(51);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 89:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'o') ADVANCE(45);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'n') ADVANCE(48);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 90:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'o') ADVANCE(87);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'n') ADVANCE(52);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 91:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'o') ADVANCE(83);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'n') ADVANCE(104);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 92:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'o') ADVANCE(75);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'o') ADVANCE(47);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 93:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'p') ADVANCE(103);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'o') ADVANCE(46);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 94:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'p') ADVANCE(60);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'o') ADVANCE(91);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 95:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'r') ADVANCE(108);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'o') ADVANCE(87);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 96:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'r') ADVANCE(263);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'o') ADVANCE(78);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 97:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'r') ADVANCE(291);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'p') ADVANCE(107);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 98:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'r') ADVANCE(72);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'p') ADVANCE(61);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 99:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'r') ADVANCE(92);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'r') ADVANCE(112);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 100:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 's') ADVANCE(107);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'r') ADVANCE(284);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 101:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 's') ADVANCE(68);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'r') ADVANCE(311);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 102:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 's') ADVANCE(56);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'r') ADVANCE(75);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 103:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 't') ADVANCE(289);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'r') ADVANCE(96);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 104:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 't') ADVANCE(279);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 's') ADVANCE(111);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 105:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 't') ADVANCE(106);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 's') ADVANCE(69);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 106:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 't') ADVANCE(57);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 's') ADVANCE(57);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 107:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'u') ADVANCE(82);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 't') ADVANCE(309);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 108:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'u') ADVANCE(55);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 't') ADVANCE(299);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 109:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'y') ADVANCE(101);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 't') ADVANCE(110);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 110:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'y') ADVANCE(44);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 't') ADVANCE(58);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 111:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(227);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(227);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(227);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'u') ADVANCE(86);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 112:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(16);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(111);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(199);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'u') ADVANCE(56);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 113:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(18);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(112);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(201);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'y') ADVANCE(105);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 114:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(20);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(113);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(200);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'y') ADVANCE(45);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 115:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(22);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(114);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(202);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(277);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(278);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(280);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 116:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(247);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(125);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 117:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == 'a') ADVANCE(130);
-      if (('b' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      if (lookahead == '_') ADVANCE(208);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(16);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(115);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(209);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 118:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == 'b') ADVANCE(128);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      if (lookahead == '_') ADVANCE(208);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(17);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(116);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(207);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 119:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == 'd') ADVANCE(262);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      if (lookahead == '_') ADVANCE(208);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(18);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(117);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(211);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 120:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == 'e') ADVANCE(260);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      if (lookahead == '_') ADVANCE(208);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(19);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(118);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(213);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 121:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == 'e') ADVANCE(136);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      if (lookahead == '_') ADVANCE(208);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(20);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(119);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(210);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 122:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == 'e') ADVANCE(134);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      if (lookahead == '_') ADVANCE(208);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(21);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(120);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(212);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 123:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == 'e') ADVANCE(254);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      if (lookahead == '_') ADVANCE(208);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(22);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(121);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(214);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 124:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == 'f') ADVANCE(127);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      if (lookahead == '_') ADVANCE(208);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(23);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(122);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(215);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 125:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == 'g') ADVANCE(139);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      if (lookahead == '_') ADVANCE(208);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 126:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == 'i') ADVANCE(129);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      if (lookahead == 'a') ADVANCE(139);
+      if (('b' <= lookahead && lookahead <= 'z')) ADVANCE(146);
       END_STATE();
     case 127:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == 'i') ADVANCE(125);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      if (lookahead == 'b') ADVANCE(137);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
       END_STATE();
     case 128:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == 'i') ADVANCE(132);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      if (lookahead == 'd') ADVANCE(283);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
       END_STATE();
     case 129:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == 'l') ADVANCE(120);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      if (lookahead == 'e') ADVANCE(281);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
       END_STATE();
     case 130:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == 'l') ADVANCE(122);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      if (lookahead == 'e') ADVANCE(145);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
       END_STATE();
     case 131:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == 'n') ADVANCE(124);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      if (lookahead == 'e') ADVANCE(143);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
       END_STATE();
     case 132:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == 'n') ADVANCE(119);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      if (lookahead == 'e') ADVANCE(272);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
       END_STATE();
     case 133:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == 'o') ADVANCE(131);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      if (lookahead == 'f') ADVANCE(136);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
       END_STATE();
     case 134:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == 't') ADVANCE(135);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      if (lookahead == 'g') ADVANCE(148);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
       END_STATE();
     case 135:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == 't') ADVANCE(123);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      if (lookahead == 'i') ADVANCE(138);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
       END_STATE();
     case 136:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == 'y') ADVANCE(118);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      if (lookahead == 'i') ADVANCE(134);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
       END_STATE();
     case 137:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
       if (lookahead == '-') ADVANCE(28);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      if (lookahead == 'i') ADVANCE(141);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
       END_STATE();
     case 138:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
-      if (lookahead == '-') ADVANCE(10);
-      if (lookahead == '_') ADVANCE(198);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == 'l') ADVANCE(129);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
       END_STATE();
     case 139:
       ACCEPT_TOKEN(sym__kebab_case_identifier);
-      if (lookahead == '-') ADVANCE(10);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == 'l') ADVANCE(131);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
       END_STATE();
     case 140:
-      ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'a') ADVANCE(185);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == 'n') ADVANCE(133);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
       END_STATE();
     case 141:
-      ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'a') ADVANCE(175);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == 'n') ADVANCE(128);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
       END_STATE();
     case 142:
-      ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'a') ADVANCE(164);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == 'o') ADVANCE(140);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
       END_STATE();
     case 143:
-      ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'a') ADVANCE(165);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == 't') ADVANCE(144);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
       END_STATE();
     case 144:
-      ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'a') ADVANCE(167);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == 't') ADVANCE(132);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
       END_STATE();
     case 145:
-      ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'b') ADVANCE(143);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == 'y') ADVANCE(127);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
       END_STATE();
     case 146:
-      ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'c') ADVANCE(142);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(28);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
       END_STATE();
     case 147:
-      ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'c') ADVANCE(180);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(12);
+      if (lookahead == '_') ADVANCE(208);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 148:
-      ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'c') ADVANCE(144);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      ACCEPT_TOKEN(sym__kebab_case_identifier);
+      if (lookahead == '-') ADVANCE(12);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
       END_STATE();
     case 149:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'd') ADVANCE(294);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'a') ADVANCE(194);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 150:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'd') ADVANCE(296);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'a') ADVANCE(184);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 151:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'd') ADVANCE(272);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'a') ADVANCE(173);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 152:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'e') ADVANCE(140);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'a') ADVANCE(174);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 153:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'e') ADVANCE(151);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'a') ADVANCE(176);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 154:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'e') ADVANCE(186);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'b') ADVANCE(152);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 155:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'f') ADVANCE(193);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'c') ADVANCE(151);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 156:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'h') ADVANCE(196);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'c') ADVANCE(189);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 157:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'h') ADVANCE(158);
-      if (lookahead == 'u') ADVANCE(184);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'c') ADVANCE(153);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 158:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'i') ADVANCE(155);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'd') ADVANCE(314);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 159:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'i') ADVANCE(148);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'd') ADVANCE(316);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 160:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'l') ADVANCE(162);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'd') ADVANCE(293);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 161:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'l') ADVANCE(152);
-      if (lookahead == 'm') ADVANCE(149);
-      if (lookahead == 'o') ADVANCE(171);
-      if (lookahead == 't') ADVANCE(187);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'e') ADVANCE(149);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 162:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'l') ADVANCE(266);
-      if (lookahead == 't') ADVANCE(286);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'e') ADVANCE(160);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 163:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'l') ADVANCE(282);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'e') ADVANCE(195);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 164:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'l') ADVANCE(270);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'f') ADVANCE(202);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 165:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'l') ADVANCE(268);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'h') ADVANCE(205);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 166:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'l') ADVANCE(284);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'h') ADVANCE(167);
+      if (lookahead == 'u') ADVANCE(193);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 167:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'l') ADVANCE(275);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'i') ADVANCE(164);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 168:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'l') ADVANCE(179);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'i') ADVANCE(157);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 169:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'l') ADVANCE(191);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'l') ADVANCE(171);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 170:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'm') ADVANCE(149);
-      if (lookahead == 'o') ADVANCE(171);
-      if (lookahead == 't') ADVANCE(187);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'l') ADVANCE(161);
+      if (lookahead == 'm') ADVANCE(158);
+      if (lookahead == 'o') ADVANCE(180);
+      if (lookahead == 't') ADVANCE(196);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 171:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'm') ADVANCE(173);
-      if (lookahead == 'n') ADVANCE(194);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'l') ADVANCE(287);
+      if (lookahead == 't') ADVANCE(306);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 172:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'm') ADVANCE(153);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'l') ADVANCE(302);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 173:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'm') ADVANCE(141);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'l') ADVANCE(291);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 174:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'n') ADVANCE(288);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'l') ADVANCE(289);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 175:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'n') ADVANCE(150);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'l') ADVANCE(304);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 176:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'n') ADVANCE(147);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'l') ADVANCE(296);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 177:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'n') ADVANCE(189);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'l') ADVANCE(188);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 178:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'o') ADVANCE(146);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'l') ADVANCE(200);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 179:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'o') ADVANCE(145);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'm') ADVANCE(158);
+      if (lookahead == 'o') ADVANCE(180);
+      if (lookahead == 't') ADVANCE(196);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 180:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'o') ADVANCE(177);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'm') ADVANCE(182);
+      if (lookahead == 'n') ADVANCE(203);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 181:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'o') ADVANCE(174);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'm') ADVANCE(162);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 182:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'o') ADVANCE(166);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'm') ADVANCE(150);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 183:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'p') ADVANCE(192);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'n') ADVANCE(308);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 184:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'p') ADVANCE(154);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'n') ADVANCE(159);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 185:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'r') ADVANCE(264);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'n') ADVANCE(156);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 186:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'r') ADVANCE(292);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'n') ADVANCE(198);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 187:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'r') ADVANCE(163);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'o') ADVANCE(155);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 188:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'r') ADVANCE(182);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'o') ADVANCE(154);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 189:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 's') ADVANCE(195);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'o') ADVANCE(186);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 190:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 's') ADVANCE(159);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'o') ADVANCE(183);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 191:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 't') ADVANCE(286);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'o') ADVANCE(175);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 192:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 't') ADVANCE(290);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'p') ADVANCE(201);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 193:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 't') ADVANCE(280);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'p') ADVANCE(163);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 194:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 't') ADVANCE(188);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'r') ADVANCE(285);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 195:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'u') ADVANCE(172);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'r') ADVANCE(312);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 196:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (lookahead == 'y') ADVANCE(190);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'r') ADVANCE(172);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 197:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 'r') ADVANCE(191);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 198:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == 's') ADVANCE(204);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 199:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(227);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(227);
+      if (lookahead == 's') ADVANCE(168);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 200:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(201);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(18);
+      if (lookahead == 't') ADVANCE(306);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 201:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(199);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(16);
+      if (lookahead == 't') ADVANCE(310);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 202:
       ACCEPT_TOKEN(sym__snake_case_identifier);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(200);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(20);
+      if (lookahead == 't') ADVANCE(300);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 203:
-      ACCEPT_TOKEN(anon_sym_true);
-      if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 't') ADVANCE(197);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 204:
-      ACCEPT_TOKEN(anon_sym_true);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(252);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'u') ADVANCE(181);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 205:
-      ACCEPT_TOKEN(anon_sym_false);
-      if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (lookahead == 'y') ADVANCE(199);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 206:
-      ACCEPT_TOKEN(anon_sym_false);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(252);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       END_STATE();
     case 207:
-      ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '%') ADVANCE(228);
-      if (lookahead == '.') ADVANCE(14);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(227);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(227);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(247);
       END_STATE();
     case 208:
-      ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '%') ADVANCE(228);
-      if (lookahead == '.') ADVANCE(14);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(209);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
+      END_STATE();
+    case 209:
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(280);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(277);
+      END_STATE();
+    case 210:
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(211);
       if (('A' <= lookahead && lookahead <= 'F') ||
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(18);
       END_STATE();
-    case 209:
-      ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '%') ADVANCE(228);
-      if (lookahead == '.') ADVANCE(14);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(207);
+    case 211:
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(209);
       if (('A' <= lookahead && lookahead <= 'F') ||
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(16);
       END_STATE();
-    case 210:
-      ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '%') ADVANCE(228);
-      if (lookahead == '.') ADVANCE(14);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(208);
+    case 212:
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(213);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(19);
+      END_STATE();
+    case 213:
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(207);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(17);
+      END_STATE();
+    case 214:
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(210);
       if (('A' <= lookahead && lookahead <= 'F') ||
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(20);
       END_STATE();
-    case 211:
-      ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '%') ADVANCE(228);
-      if (lookahead == '.') ADVANCE(14);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(210);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(22);
-      END_STATE();
-    case 212:
-      ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '%') ADVANCE(228);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(212);
-      END_STATE();
-    case 213:
-      ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '%') ADVANCE(229);
-      if (lookahead == '.') ADVANCE(244);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(227);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(227);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(252);
-      END_STATE();
-    case 214:
-      ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '%') ADVANCE(229);
-      if (lookahead == '.') ADVANCE(244);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(215);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(247);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(252);
-      END_STATE();
     case 215:
-      ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '%') ADVANCE(229);
-      if (lookahead == '.') ADVANCE(244);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(213);
+      ACCEPT_TOKEN(sym__snake_case_identifier);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(212);
       if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(246);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(252);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(21);
       END_STATE();
     case 216:
+      ACCEPT_TOKEN(anon_sym_true);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(208);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+      END_STATE();
+    case 217:
+      ACCEPT_TOKEN(anon_sym_true);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(270);
+      END_STATE();
+    case 218:
+      ACCEPT_TOKEN(anon_sym_false);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(208);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+      END_STATE();
+    case 219:
+      ACCEPT_TOKEN(anon_sym_false);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(270);
+      END_STATE();
+    case 220:
       ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '%') ADVANCE(229);
-      if (lookahead == '.') ADVANCE(244);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(214);
+      if (lookahead == '%') ADVANCE(249);
+      if (lookahead == '.') ADVANCE(262);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(221);
       if (('A' <= lookahead && lookahead <= 'F') ||
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(248);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(252);
-      END_STATE();
-    case 217:
-      ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '%') ADVANCE(229);
-      if (lookahead == '.') ADVANCE(244);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(216);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(249);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(252);
-      END_STATE();
-    case 218:
-      ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '%') ADVANCE(229);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(218);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(252);
-      END_STATE();
-    case 219:
-      ACCEPT_TOKEN(anon_sym_DQUOTE);
-      END_STATE();
-    case 220:
-      ACCEPT_TOKEN(anon_sym_DQUOTE);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(252);
+          lookahead != '\r') ADVANCE(270);
       END_STATE();
     case 221:
-      ACCEPT_TOKEN(aux_sym_string_literal_token1);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(221);
+      ACCEPT_TOKEN(sym_number_literal);
+      if (lookahead == '%') ADVANCE(249);
+      if (lookahead == '.') ADVANCE(262);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(221);
       if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(222);
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(270);
       END_STATE();
     case 222:
-      ACCEPT_TOKEN(aux_sym_string_literal_token1);
+      ACCEPT_TOKEN(sym_number_literal);
+      if (lookahead == '%') ADVANCE(249);
+      if (lookahead == '.') ADVANCE(262);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(223);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(265);
       if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(222);
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(270);
       END_STATE();
     case 223:
-      ACCEPT_TOKEN(anon_sym_SQUOTE);
+      ACCEPT_TOKEN(sym_number_literal);
+      if (lookahead == '%') ADVANCE(249);
+      if (lookahead == '.') ADVANCE(262);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(220);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(264);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(270);
       END_STATE();
     case 224:
+      ACCEPT_TOKEN(sym_number_literal);
+      if (lookahead == '%') ADVANCE(249);
+      if (lookahead == '.') ADVANCE(262);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(222);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(266);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(270);
+      END_STATE();
+    case 225:
+      ACCEPT_TOKEN(sym_number_literal);
+      if (lookahead == '%') ADVANCE(249);
+      if (lookahead == '.') ADVANCE(262);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(224);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(267);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(270);
+      END_STATE();
+    case 226:
+      ACCEPT_TOKEN(sym_number_literal);
+      if (lookahead == '%') ADVANCE(249);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(226);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(270);
+      END_STATE();
+    case 227:
+      ACCEPT_TOKEN(sym_number_literal);
+      if (lookahead == '.') ADVANCE(15);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(279);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(277);
+      END_STATE();
+    case 228:
+      ACCEPT_TOKEN(sym_number_literal);
+      if (lookahead == '.') ADVANCE(15);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(228);
+      END_STATE();
+    case 229:
+      ACCEPT_TOKEN(sym_number_literal);
+      if (lookahead == '.') ADVANCE(15);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(228);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(247);
+      END_STATE();
+    case 230:
+      ACCEPT_TOKEN(sym_number_literal);
+      if (lookahead == '.') ADVANCE(15);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(232);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(18);
+      END_STATE();
+    case 231:
+      ACCEPT_TOKEN(sym_number_literal);
+      if (lookahead == '.') ADVANCE(15);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(233);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(19);
+      END_STATE();
+    case 232:
+      ACCEPT_TOKEN(sym_number_literal);
+      if (lookahead == '.') ADVANCE(15);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(227);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(16);
+      END_STATE();
+    case 233:
+      ACCEPT_TOKEN(sym_number_literal);
+      if (lookahead == '.') ADVANCE(15);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(229);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(17);
+      END_STATE();
+    case 234:
+      ACCEPT_TOKEN(sym_number_literal);
+      if (lookahead == '.') ADVANCE(15);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(230);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(20);
+      END_STATE();
+    case 235:
+      ACCEPT_TOKEN(sym_number_literal);
+      if (lookahead == '.') ADVANCE(15);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(231);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(21);
+      END_STATE();
+    case 236:
+      ACCEPT_TOKEN(sym_number_literal);
+      if (lookahead == '.') ADVANCE(15);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(234);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(22);
+      END_STATE();
+    case 237:
+      ACCEPT_TOKEN(sym_number_literal);
+      if (lookahead == '.') ADVANCE(15);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(235);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(23);
+      END_STATE();
+    case 238:
+      ACCEPT_TOKEN(sym_number_literal);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(238);
+      END_STATE();
+    case 239:
+      ACCEPT_TOKEN(anon_sym_DQUOTE);
+      END_STATE();
+    case 240:
+      ACCEPT_TOKEN(anon_sym_DQUOTE);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(270);
+      END_STATE();
+    case 241:
+      ACCEPT_TOKEN(aux_sym_string_literal_token1);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(241);
+      if (lookahead != 0 &&
+          lookahead != '"') ADVANCE(242);
+      END_STATE();
+    case 242:
+      ACCEPT_TOKEN(aux_sym_string_literal_token1);
+      if (lookahead != 0 &&
+          lookahead != '"') ADVANCE(242);
+      END_STATE();
+    case 243:
+      ACCEPT_TOKEN(anon_sym_SQUOTE);
+      END_STATE();
+    case 244:
       ACCEPT_TOKEN(anon_sym_SQUOTE);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(252);
+          lookahead != '\r') ADVANCE(270);
       END_STATE();
-    case 225:
+    case 245:
       ACCEPT_TOKEN(aux_sym_string_literal_token2);
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(225);
+          lookahead == ' ') ADVANCE(245);
       if (lookahead != 0 &&
-          lookahead != '\'') ADVANCE(226);
+          lookahead != '\'') ADVANCE(246);
       END_STATE();
-    case 226:
+    case 246:
       ACCEPT_TOKEN(aux_sym_string_literal_token2);
       if (lookahead != 0 &&
-          lookahead != '\'') ADVANCE(226);
+          lookahead != '\'') ADVANCE(246);
       END_STATE();
-    case 227:
+    case 247:
       ACCEPT_TOKEN(sym_color_value);
       END_STATE();
-    case 228:
+    case 248:
+      ACCEPT_TOKEN(sym_color_value);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(270);
+      END_STATE();
+    case 249:
       ACCEPT_TOKEN(sym_percent_adjustment);
-      END_STATE();
-    case 229:
-      ACCEPT_TOKEN(sym_percent_adjustment);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(252);
+          lookahead != '\r') ADVANCE(270);
       END_STATE();
-    case 230:
+    case 250:
       ACCEPT_TOKEN(sym_numeric_adjustment);
-      if (lookahead == '%') ADVANCE(228);
-      if (lookahead == '.') ADVANCE(15);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(230);
-      END_STATE();
-    case 231:
-      ACCEPT_TOKEN(sym_numeric_adjustment);
-      if (lookahead == '%') ADVANCE(228);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(231);
-      END_STATE();
-    case 232:
-      ACCEPT_TOKEN(sym_numeric_adjustment);
-      if (lookahead == '%') ADVANCE(229);
-      if (lookahead == '.') ADVANCE(245);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(232);
+      if (lookahead == '%') ADVANCE(249);
+      if (lookahead == '.') ADVANCE(263);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(250);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(252);
+          lookahead != '\r') ADVANCE(270);
       END_STATE();
-    case 233:
+    case 251:
       ACCEPT_TOKEN(sym_numeric_adjustment);
-      if (lookahead == '%') ADVANCE(229);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(233);
+      if (lookahead == '%') ADVANCE(249);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(251);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(252);
+          lookahead != '\r') ADVANCE(270);
       END_STATE();
-    case 234:
+    case 252:
       ACCEPT_TOKEN(aux_sym_raw_value_token1);
       ADVANCE_MAP(
         '\n', 34,
         '\r', 4,
-        '"', 220,
-        '#', 251,
-        '\'', 224,
-        'f', 235,
-        't', 239,
-        '+', 243,
-        '-', 243,
-        '\t', 234,
-        0x0b, 234,
-        '\f', 234,
-        ' ', 234,
+        '"', 240,
+        '#', 269,
+        '\'', 244,
+        'f', 253,
+        't', 257,
+        '+', 261,
+        '-', 261,
+        '\t', 252,
+        0x0b, 252,
+        '\f', 252,
+        ' ', 252,
       );
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(217);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(225);
       if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'e')) ADVANCE(250);
-      if (lookahead != 0) ADVANCE(252);
+          ('a' <= lookahead && lookahead <= 'e')) ADVANCE(268);
+      if (lookahead != 0) ADVANCE(270);
       END_STATE();
-    case 235:
+    case 253:
       ACCEPT_TOKEN(aux_sym_raw_value_token1);
-      if (lookahead == 'a') ADVANCE(238);
+      if (lookahead == 'a') ADVANCE(256);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('b' <= lookahead && lookahead <= 'f')) ADVANCE(249);
+          ('b' <= lookahead && lookahead <= 'f')) ADVANCE(267);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(252);
+          lookahead != '\r') ADVANCE(270);
       END_STATE();
-    case 236:
+    case 254:
       ACCEPT_TOKEN(aux_sym_raw_value_token1);
-      if (lookahead == 'e') ADVANCE(204);
+      if (lookahead == 'e') ADVANCE(217);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(252);
+          lookahead != '\r') ADVANCE(270);
       END_STATE();
-    case 237:
+    case 255:
       ACCEPT_TOKEN(aux_sym_raw_value_token1);
-      if (lookahead == 'e') ADVANCE(206);
+      if (lookahead == 'e') ADVANCE(219);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(252);
+          lookahead != '\r') ADVANCE(270);
       END_STATE();
-    case 238:
+    case 256:
       ACCEPT_TOKEN(aux_sym_raw_value_token1);
-      if (lookahead == 'l') ADVANCE(240);
+      if (lookahead == 'l') ADVANCE(258);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(248);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(266);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(252);
+          lookahead != '\r') ADVANCE(270);
       END_STATE();
-    case 239:
+    case 257:
       ACCEPT_TOKEN(aux_sym_raw_value_token1);
-      if (lookahead == 'r') ADVANCE(241);
+      if (lookahead == 'r') ADVANCE(259);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(252);
+          lookahead != '\r') ADVANCE(270);
       END_STATE();
-    case 240:
+    case 258:
       ACCEPT_TOKEN(aux_sym_raw_value_token1);
-      if (lookahead == 's') ADVANCE(237);
+      if (lookahead == 's') ADVANCE(255);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(252);
+          lookahead != '\r') ADVANCE(270);
       END_STATE();
-    case 241:
+    case 259:
       ACCEPT_TOKEN(aux_sym_raw_value_token1);
-      if (lookahead == 'u') ADVANCE(236);
+      if (lookahead == 'u') ADVANCE(254);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(252);
+          lookahead != '\r') ADVANCE(270);
       END_STATE();
-    case 242:
+    case 260:
       ACCEPT_TOKEN(aux_sym_raw_value_token1);
       if (lookahead == '\t' ||
           lookahead == 0x0b ||
           lookahead == '\f' ||
-          lookahead == ' ') ADVANCE(242);
+          lookahead == ' ') ADVANCE(260);
       if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(252);
+          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(270);
       END_STATE();
-    case 243:
+    case 261:
       ACCEPT_TOKEN(aux_sym_raw_value_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(232);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(250);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(252);
+          lookahead != '\r') ADVANCE(270);
       END_STATE();
-    case 244:
+    case 262:
       ACCEPT_TOKEN(aux_sym_raw_value_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(218);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(226);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(252);
+          lookahead != '\r') ADVANCE(270);
       END_STATE();
-    case 245:
+    case 263:
       ACCEPT_TOKEN(aux_sym_raw_value_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(233);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(251);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(252);
+          lookahead != '\r') ADVANCE(270);
       END_STATE();
-    case 246:
-      ACCEPT_TOKEN(aux_sym_raw_value_token1);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(227);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(252);
-      END_STATE();
-    case 247:
-      ACCEPT_TOKEN(aux_sym_raw_value_token1);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(246);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(252);
-      END_STATE();
-    case 248:
-      ACCEPT_TOKEN(aux_sym_raw_value_token1);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(247);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(252);
-      END_STATE();
-    case 249:
+    case 264:
       ACCEPT_TOKEN(aux_sym_raw_value_token1);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(248);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(252);
-      END_STATE();
-    case 250:
-      ACCEPT_TOKEN(aux_sym_raw_value_token1);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(249);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(252);
-      END_STATE();
-    case 251:
-      ACCEPT_TOKEN(aux_sym_raw_value_token1);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(250);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(252);
-      END_STATE();
-    case 252:
-      ACCEPT_TOKEN(aux_sym_raw_value_token1);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(252);
-      END_STATE();
-    case 253:
-      ACCEPT_TOKEN(anon_sym_palette);
-      if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
-      END_STATE();
-    case 254:
-      ACCEPT_TOKEN(anon_sym_palette);
-      if (lookahead == '-') ADVANCE(28);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
-      END_STATE();
-    case 255:
-      ACCEPT_TOKEN(aux_sym_palette_value_token1);
-      END_STATE();
-    case 256:
-      ACCEPT_TOKEN(aux_sym_palette_value_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(255);
-      END_STATE();
-    case 257:
-      ACCEPT_TOKEN(aux_sym_palette_value_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(256);
-      END_STATE();
-    case 258:
-      ACCEPT_TOKEN(anon_sym_EQ2);
-      END_STATE();
-    case 259:
-      ACCEPT_TOKEN(aux_sym_palette_value_token2);
-      END_STATE();
-    case 260:
-      ACCEPT_TOKEN(anon_sym_config_DASHfile);
-      if (lookahead == '-') ADVANCE(28);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
-      END_STATE();
-    case 261:
-      ACCEPT_TOKEN(anon_sym_keybind);
-      if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
-      END_STATE();
-    case 262:
-      ACCEPT_TOKEN(anon_sym_keybind);
-      if (lookahead == '-') ADVANCE(28);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
-      END_STATE();
-    case 263:
-      ACCEPT_TOKEN(anon_sym_clear);
-      if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
-      END_STATE();
-    case 264:
-      ACCEPT_TOKEN(anon_sym_clear);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          lookahead != '\r') ADVANCE(270);
       END_STATE();
     case 265:
-      ACCEPT_TOKEN(anon_sym_all);
-      if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      ACCEPT_TOKEN(aux_sym_raw_value_token1);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(264);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(270);
       END_STATE();
     case 266:
-      ACCEPT_TOKEN(anon_sym_all);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      ACCEPT_TOKEN(aux_sym_raw_value_token1);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(265);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(270);
       END_STATE();
     case 267:
-      ACCEPT_TOKEN(anon_sym_global);
-      if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      ACCEPT_TOKEN(aux_sym_raw_value_token1);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(266);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(270);
       END_STATE();
     case 268:
-      ACCEPT_TOKEN(anon_sym_global);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      ACCEPT_TOKEN(aux_sym_raw_value_token1);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(267);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(270);
       END_STATE();
     case 269:
-      ACCEPT_TOKEN(anon_sym_local);
-      if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      ACCEPT_TOKEN(aux_sym_raw_value_token1);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(268);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(270);
       END_STATE();
     case 270:
-      ACCEPT_TOKEN(anon_sym_local);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      ACCEPT_TOKEN(aux_sym_raw_value_token1);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(270);
       END_STATE();
     case 271:
-      ACCEPT_TOKEN(anon_sym_unconsumed);
+      ACCEPT_TOKEN(anon_sym_palette);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 272:
-      ACCEPT_TOKEN(anon_sym_unconsumed);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      ACCEPT_TOKEN(anon_sym_palette);
+      if (lookahead == '-') ADVANCE(28);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
       END_STATE();
     case 273:
-      ACCEPT_TOKEN(anon_sym_COLON);
+      ACCEPT_TOKEN(aux_sym_palette_value_token1);
       END_STATE();
     case 274:
-      ACCEPT_TOKEN(sym_key_prefix);
-      if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      ACCEPT_TOKEN(aux_sym_palette_value_token1);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(273);
       END_STATE();
     case 275:
-      ACCEPT_TOKEN(sym_key_prefix);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      ACCEPT_TOKEN(aux_sym_palette_value_token1);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(274);
       END_STATE();
     case 276:
-      ACCEPT_TOKEN(anon_sym_GT);
+      ACCEPT_TOKEN(anon_sym_EQ2);
       END_STATE();
     case 277:
-      ACCEPT_TOKEN(anon_sym_PLUS);
+      ACCEPT_TOKEN(aux_sym_palette_value_token2);
       END_STATE();
     case 278:
-      ACCEPT_TOKEN(anon_sym_PLUS);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(230);
+      ACCEPT_TOKEN(aux_sym_palette_value_token2);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(208);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 279:
-      ACCEPT_TOKEN(anon_sym_shift);
-      if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      ACCEPT_TOKEN(aux_sym_palette_value_token2);
+      if (lookahead == '.') ADVANCE(15);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(228);
       END_STATE();
     case 280:
-      ACCEPT_TOKEN(anon_sym_shift);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      ACCEPT_TOKEN(aux_sym_palette_value_token2);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       END_STATE();
     case 281:
-      ACCEPT_TOKEN(anon_sym_ctrl);
+      ACCEPT_TOKEN(anon_sym_config_DASHfile);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
       END_STATE();
     case 282:
-      ACCEPT_TOKEN(anon_sym_ctrl);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      ACCEPT_TOKEN(anon_sym_keybind);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(208);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 283:
-      ACCEPT_TOKEN(anon_sym_control);
+      ACCEPT_TOKEN(anon_sym_keybind);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
       END_STATE();
     case 284:
-      ACCEPT_TOKEN(anon_sym_control);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      ACCEPT_TOKEN(anon_sym_clear);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(208);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 285:
-      ACCEPT_TOKEN(anon_sym_alt);
-      if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      ACCEPT_TOKEN(anon_sym_clear);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 286:
-      ACCEPT_TOKEN(anon_sym_alt);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      ACCEPT_TOKEN(anon_sym_all);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(208);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 287:
-      ACCEPT_TOKEN(anon_sym_option);
-      if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      ACCEPT_TOKEN(anon_sym_all);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 288:
-      ACCEPT_TOKEN(anon_sym_option);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      ACCEPT_TOKEN(anon_sym_global);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(208);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 289:
-      ACCEPT_TOKEN(anon_sym_opt);
-      if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (lookahead == 'i') ADVANCE(91);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      ACCEPT_TOKEN(anon_sym_global);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 290:
-      ACCEPT_TOKEN(anon_sym_opt);
-      if (lookahead == 'i') ADVANCE(181);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      ACCEPT_TOKEN(anon_sym_local);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(208);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 291:
-      ACCEPT_TOKEN(anon_sym_super);
-      if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      ACCEPT_TOKEN(anon_sym_local);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 292:
-      ACCEPT_TOKEN(anon_sym_super);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      ACCEPT_TOKEN(anon_sym_unconsumed);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(208);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 293:
-      ACCEPT_TOKEN(anon_sym_cmd);
-      if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      ACCEPT_TOKEN(anon_sym_unconsumed);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
       END_STATE();
     case 294:
-      ACCEPT_TOKEN(anon_sym_cmd);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+      ACCEPT_TOKEN(anon_sym_COLON);
       END_STATE();
     case 295:
-      ACCEPT_TOKEN(anon_sym_command);
+      ACCEPT_TOKEN(anon_sym_physical);
       if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(198);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
+      if (lookahead == '_') ADVANCE(208);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 296:
-      ACCEPT_TOKEN(anon_sym_command);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      ACCEPT_TOKEN(anon_sym_physical);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(198);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
+      END_STATE();
+    case 297:
+      ACCEPT_TOKEN(anon_sym_GT);
+      END_STATE();
+    case 298:
+      ACCEPT_TOKEN(anon_sym_PLUS);
+      END_STATE();
+    case 299:
+      ACCEPT_TOKEN(anon_sym_shift);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(208);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+      END_STATE();
+    case 300:
+      ACCEPT_TOKEN(anon_sym_shift);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
+      END_STATE();
+    case 301:
+      ACCEPT_TOKEN(anon_sym_ctrl);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(208);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+      END_STATE();
+    case 302:
+      ACCEPT_TOKEN(anon_sym_ctrl);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
+      END_STATE();
+    case 303:
+      ACCEPT_TOKEN(anon_sym_control);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(208);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+      END_STATE();
+    case 304:
+      ACCEPT_TOKEN(anon_sym_control);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
+      END_STATE();
+    case 305:
+      ACCEPT_TOKEN(anon_sym_alt);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(208);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+      END_STATE();
+    case 306:
+      ACCEPT_TOKEN(anon_sym_alt);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
+      END_STATE();
+    case 307:
+      ACCEPT_TOKEN(anon_sym_option);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(208);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+      END_STATE();
+    case 308:
+      ACCEPT_TOKEN(anon_sym_option);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
+      END_STATE();
+    case 309:
+      ACCEPT_TOKEN(anon_sym_opt);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(208);
+      if (lookahead == 'i') ADVANCE(95);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+      END_STATE();
+    case 310:
+      ACCEPT_TOKEN(anon_sym_opt);
+      if (lookahead == 'i') ADVANCE(190);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
+      END_STATE();
+    case 311:
+      ACCEPT_TOKEN(anon_sym_super);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(208);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+      END_STATE();
+    case 312:
+      ACCEPT_TOKEN(anon_sym_super);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
+      END_STATE();
+    case 313:
+      ACCEPT_TOKEN(anon_sym_cmd);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(208);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+      END_STATE();
+    case 314:
+      ACCEPT_TOKEN(anon_sym_cmd);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
+      END_STATE();
+    case 315:
+      ACCEPT_TOKEN(anon_sym_command);
+      if (lookahead == '-') ADVANCE(28);
+      if (lookahead == '_') ADVANCE(208);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+      END_STATE();
+    case 316:
+      ACCEPT_TOKEN(anon_sym_command);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(206);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
+      END_STATE();
+    case 317:
+      ACCEPT_TOKEN(aux_sym_key_token1);
+      END_STATE();
+    case 318:
+      ACCEPT_TOKEN(aux_sym_key_token1);
+      ADVANCE_MAP(
+        '"', 239,
+        '\'', 243,
+        'a', 169,
+        'c', 170,
+        'g', 177,
+        'l', 187,
+        'o', 192,
+        'p', 165,
+        's', 166,
+        'u', 185,
+      );
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(318);
+      if (lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(208);
+      if (lookahead != 0 &&
+          lookahead != ':' &&
+          lookahead != '=' &&
+          lookahead != '>') ADVANCE(317);
+      END_STATE();
+    case 319:
+      ACCEPT_TOKEN(aux_sym_key_token1);
+      ADVANCE_MAP(
+        'a', 169,
+        'c', 179,
+        'g', 177,
+        'l', 187,
+        'o', 192,
+        'p', 165,
+        's', 166,
+        'u', 185,
+      );
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(319);
+      if (lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(208);
+      if (lookahead != 0 &&
+          lookahead != ':' &&
+          lookahead != '=' &&
+          lookahead != '>') ADVANCE(317);
+      END_STATE();
+    case 320:
+      ACCEPT_TOKEN(aux_sym_key_token1);
+      if (lookahead == 'a') ADVANCE(178);
+      if (lookahead == 'c') ADVANCE(179);
+      if (lookahead == 'o') ADVANCE(192);
+      if (lookahead == 'p') ADVANCE(165);
+      if (lookahead == 's') ADVANCE(166);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(320);
+      if (lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(208);
+      if (lookahead != 0 &&
+          lookahead != ':' &&
+          lookahead != '=' &&
+          lookahead != '>') ADVANCE(317);
+      END_STATE();
+    case 321:
+      ACCEPT_TOKEN(aux_sym_key_token1);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(321);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
+      if (lookahead != 0 &&
+          lookahead != ':' &&
+          lookahead != '=' &&
+          lookahead != '>') ADVANCE(317);
       END_STATE();
     default:
       return false;
@@ -2879,14 +3144,14 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
   [1] = {.lex_state = 29},
   [2] = {.lex_state = 5},
-  [3] = {.lex_state = 8},
-  [4] = {.lex_state = 8},
-  [5] = {.lex_state = 4},
-  [6] = {.lex_state = 8},
-  [7] = {.lex_state = 29},
-  [8] = {.lex_state = 29},
-  [9] = {.lex_state = 9},
-  [10] = {.lex_state = 9},
+  [3] = {.lex_state = 10},
+  [4] = {.lex_state = 10},
+  [5] = {.lex_state = 11},
+  [6] = {.lex_state = 10},
+  [7] = {.lex_state = 4},
+  [8] = {.lex_state = 11},
+  [9] = {.lex_state = 29},
+  [10] = {.lex_state = 29},
   [11] = {.lex_state = 29},
   [12] = {.lex_state = 29},
   [13] = {.lex_state = 29},
@@ -2894,55 +3159,56 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [15] = {.lex_state = 29},
   [16] = {.lex_state = 29},
   [17] = {.lex_state = 29},
-  [18] = {.lex_state = 5},
-  [19] = {.lex_state = 5},
-  [20] = {.lex_state = 5},
-  [21] = {.lex_state = 5},
-  [22] = {.lex_state = 5},
-  [23] = {.lex_state = 5},
-  [24] = {.lex_state = 5},
-  [25] = {.lex_state = 5},
-  [26] = {.lex_state = 29},
-  [27] = {.lex_state = 5},
-  [28] = {.lex_state = 5},
-  [29] = {.lex_state = 11},
-  [30] = {.lex_state = 12},
-  [31] = {.lex_state = 29},
-  [32] = {.lex_state = 5},
-  [33] = {.lex_state = 11},
-  [34] = {.lex_state = 12},
-  [35] = {.lex_state = 29},
-  [36] = {.lex_state = 8},
-  [37] = {.lex_state = 29},
-  [38] = {.lex_state = 7},
-  [39] = {.lex_state = 0},
-  [40] = {.lex_state = 221},
-  [41] = {.lex_state = 0},
+  [18] = {.lex_state = 7},
+  [19] = {.lex_state = 7},
+  [20] = {.lex_state = 7},
+  [21] = {.lex_state = 29},
+  [22] = {.lex_state = 7},
+  [23] = {.lex_state = 7},
+  [24] = {.lex_state = 7},
+  [25] = {.lex_state = 7},
+  [26] = {.lex_state = 7},
+  [27] = {.lex_state = 7},
+  [28] = {.lex_state = 7},
+  [29] = {.lex_state = 7},
+  [30] = {.lex_state = 13},
+  [31] = {.lex_state = 14},
+  [32] = {.lex_state = 7},
+  [33] = {.lex_state = 29},
+  [34] = {.lex_state = 14},
+  [35] = {.lex_state = 7},
+  [36] = {.lex_state = 13},
+  [37] = {.lex_state = 6},
+  [38] = {.lex_state = 29},
+  [39] = {.lex_state = 6},
+  [40] = {.lex_state = 6},
+  [41] = {.lex_state = 29},
   [42] = {.lex_state = 0},
-  [43] = {.lex_state = 8},
-  [44] = {.lex_state = 12},
-  [45] = {.lex_state = 225},
+  [43] = {.lex_state = 0},
+  [44] = {.lex_state = 29},
+  [45] = {.lex_state = 0},
   [46] = {.lex_state = 29},
-  [47] = {.lex_state = 8},
-  [48] = {.lex_state = 0},
-  [49] = {.lex_state = 0},
-  [50] = {.lex_state = 29},
-  [51] = {.lex_state = 29},
+  [47] = {.lex_state = 29},
+  [48] = {.lex_state = 6},
+  [49] = {.lex_state = 6},
+  [50] = {.lex_state = 241},
+  [51] = {.lex_state = 245},
   [52] = {.lex_state = 29},
   [53] = {.lex_state = 29},
-  [54] = {.lex_state = 29},
-  [55] = {.lex_state = 29},
+  [54] = {.lex_state = 0},
+  [55] = {.lex_state = 0},
   [56] = {.lex_state = 29},
   [57] = {.lex_state = 29},
   [58] = {.lex_state = 29},
-  [59] = {.lex_state = 8},
-  [60] = {.lex_state = 29},
+  [59] = {.lex_state = 29},
+  [60] = {.lex_state = 6},
   [61] = {.lex_state = 29},
   [62] = {.lex_state = 29},
   [63] = {.lex_state = 29},
-  [64] = {.lex_state = 8},
+  [64] = {.lex_state = 29},
   [65] = {.lex_state = 29},
   [66] = {.lex_state = 29},
+  [67] = {.lex_state = 29},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -2957,8 +3223,6 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_DQUOTE] = ACTIONS(1),
     [anon_sym_SQUOTE] = ACTIONS(1),
     [sym_color_value] = ACTIONS(1),
-    [sym_percent_adjustment] = ACTIONS(1),
-    [sym_numeric_adjustment] = ACTIONS(1),
     [anon_sym_palette] = ACTIONS(1),
     [aux_sym_palette_value_token1] = ACTIONS(1),
     [anon_sym_EQ2] = ACTIONS(1),
@@ -2971,7 +3235,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_local] = ACTIONS(1),
     [anon_sym_unconsumed] = ACTIONS(1),
     [anon_sym_COLON] = ACTIONS(1),
-    [sym_key_prefix] = ACTIONS(1),
+    [anon_sym_physical] = ACTIONS(1),
     [anon_sym_GT] = ACTIONS(1),
     [anon_sym_PLUS] = ACTIONS(1),
     [anon_sym_shift] = ACTIONS(1),
@@ -2985,14 +3249,14 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_command] = ACTIONS(1),
   },
   [1] = {
-    [sym_source_file] = STATE(39),
-    [sym_directive] = STATE(8),
+    [sym_source_file] = STATE(45),
+    [sym_directive] = STATE(10),
     [sym_basic_directive] = STATE(11),
-    [sym_property] = STATE(43),
+    [sym_property] = STATE(40),
     [sym_palette_directive] = STATE(11),
     [sym_config_file_directive] = STATE(11),
     [sym_keybind_directive] = STATE(11),
-    [aux_sym_source_file_repeat1] = STATE(8),
+    [aux_sym_source_file_repeat1] = STATE(10),
     [ts_builtin_sym_end] = ACTIONS(3),
     [aux_sym_source_file_token1] = ACTIONS(5),
     [sym_comment] = ACTIONS(7),
@@ -3004,9 +3268,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
 };
 
 static const uint16_t ts_small_parse_table[] = {
-  [0] = 13,
-    ACTIONS(17), 1,
-      sym__snake_case_identifier,
+  [0] = 14,
     ACTIONS(19), 1,
       anon_sym_DQUOTE,
     ACTIONS(21), 1,
@@ -3014,20 +3276,25 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(23), 1,
       anon_sym_clear,
     ACTIONS(27), 1,
-      sym_key_prefix,
-    STATE(21), 1,
+      anon_sym_physical,
+    STATE(24), 1,
       sym_chord,
-    STATE(46), 1,
+    STATE(34), 1,
+      sym_key_prefix,
+    STATE(52), 1,
       sym_string_literal,
-    STATE(53), 1,
+    STATE(63), 1,
       sym_keybind_trigger,
+    ACTIONS(17), 2,
+      sym__snake_case_identifier,
+      aux_sym_key_token1,
     STATE(3), 2,
       sym_keybind_modifier,
       aux_sym_keybind_value_repeat1,
     STATE(18), 2,
       sym_key_modifier,
       sym_key,
-    STATE(52), 2,
+    STATE(61), 2,
       sym__keybind_value,
       sym_keybind_value,
     ACTIONS(25), 4,
@@ -3045,15 +3312,18 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_super,
       anon_sym_cmd,
       anon_sym_command,
-  [54] = 8,
-    ACTIONS(17), 1,
-      sym__snake_case_identifier,
+  [58] = 9,
     ACTIONS(27), 1,
-      sym_key_prefix,
-    STATE(21), 1,
+      anon_sym_physical,
+    STATE(24), 1,
       sym_chord,
-    STATE(51), 1,
+    STATE(34), 1,
+      sym_key_prefix,
+    STATE(53), 1,
       sym_keybind_trigger,
+    ACTIONS(17), 2,
+      sym__snake_case_identifier,
+      aux_sym_key_token1,
     STATE(4), 2,
       sym_keybind_modifier,
       aux_sym_keybind_value_repeat1,
@@ -3075,7 +3345,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_super,
       anon_sym_cmd,
       anon_sym_command,
-  [92] = 3,
+  [100] = 3,
     STATE(4), 2,
       sym_keybind_modifier,
       aux_sym_keybind_value_repeat1,
@@ -3084,9 +3354,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_global,
       anon_sym_local,
       anon_sym_unconsumed,
-    ACTIONS(31), 11,
+    ACTIONS(31), 12,
       sym__snake_case_identifier,
-      sym_key_prefix,
+      anon_sym_physical,
       anon_sym_shift,
       anon_sym_ctrl,
       anon_sym_control,
@@ -3096,105 +3366,17 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_super,
       anon_sym_cmd,
       anon_sym_command,
-  [116] = 9,
-    ACTIONS(36), 1,
-      aux_sym_source_file_token1,
-    ACTIONS(42), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(44), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(48), 1,
-      aux_sym_raw_value_token1,
-    STATE(37), 1,
-      sym_value,
-    ACTIONS(38), 2,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(40), 2,
-      sym_number_literal,
-      sym_color_value,
-    ACTIONS(46), 2,
-      sym_percent_adjustment,
-      sym_numeric_adjustment,
-    STATE(62), 4,
-      sym_boolean_literal,
-      sym_adjustment,
-      sym_string_literal,
-      sym_raw_value,
-  [150] = 1,
-    ACTIONS(50), 15,
-      sym__snake_case_identifier,
-      anon_sym_all,
-      anon_sym_global,
-      anon_sym_local,
-      anon_sym_unconsumed,
-      sym_key_prefix,
-      anon_sym_shift,
-      anon_sym_ctrl,
-      anon_sym_control,
-      anon_sym_alt,
-      anon_sym_option,
-      anon_sym_opt,
-      anon_sym_super,
-      anon_sym_cmd,
-      anon_sym_command,
-  [168] = 10,
-    ACTIONS(52), 1,
-      ts_builtin_sym_end,
-    ACTIONS(54), 1,
-      aux_sym_source_file_token1,
-    ACTIONS(57), 1,
-      sym_comment,
-    ACTIONS(60), 1,
-      sym__kebab_case_identifier,
-    ACTIONS(63), 1,
-      anon_sym_palette,
-    ACTIONS(66), 1,
-      anon_sym_config_DASHfile,
-    ACTIONS(69), 1,
-      anon_sym_keybind,
-    STATE(43), 1,
-      sym_property,
-    STATE(7), 2,
-      sym_directive,
-      aux_sym_source_file_repeat1,
-    STATE(11), 4,
-      sym_basic_directive,
-      sym_palette_directive,
-      sym_config_file_directive,
-      sym_keybind_directive,
-  [203] = 10,
-    ACTIONS(9), 1,
-      sym__kebab_case_identifier,
-    ACTIONS(11), 1,
-      anon_sym_palette,
-    ACTIONS(13), 1,
-      anon_sym_config_DASHfile,
-    ACTIONS(15), 1,
-      anon_sym_keybind,
-    ACTIONS(72), 1,
-      ts_builtin_sym_end,
-    ACTIONS(74), 1,
-      aux_sym_source_file_token1,
-    ACTIONS(76), 1,
-      sym_comment,
-    STATE(43), 1,
-      sym_property,
-    STATE(7), 2,
-      sym_directive,
-      aux_sym_source_file_repeat1,
-    STATE(11), 4,
-      sym_basic_directive,
-      sym_palette_directive,
-      sym_config_file_directive,
-      sym_keybind_directive,
-  [238] = 5,
-    ACTIONS(17), 1,
-      sym__snake_case_identifier,
+      aux_sym_key_token1,
+  [125] = 6,
     ACTIONS(27), 1,
-      sym_key_prefix,
-    STATE(32), 1,
+      anon_sym_physical,
+    STATE(29), 1,
       sym_chord,
+    STATE(34), 1,
+      sym_key_prefix,
+    ACTIONS(17), 2,
+      sym__snake_case_identifier,
+      aux_sym_key_token1,
     STATE(18), 2,
       sym_key_modifier,
       sym_key,
@@ -3208,11 +3390,57 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_super,
       anon_sym_cmd,
       anon_sym_command,
-  [263] = 4,
-    ACTIONS(17), 1,
+  [154] = 1,
+    ACTIONS(36), 16,
       sym__snake_case_identifier,
+      anon_sym_all,
+      anon_sym_global,
+      anon_sym_local,
+      anon_sym_unconsumed,
+      anon_sym_physical,
+      anon_sym_shift,
+      anon_sym_ctrl,
+      anon_sym_control,
+      anon_sym_alt,
+      anon_sym_option,
+      anon_sym_opt,
+      anon_sym_super,
+      anon_sym_cmd,
+      anon_sym_command,
+      aux_sym_key_token1,
+  [173] = 9,
+    ACTIONS(19), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(21), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(38), 1,
+      aux_sym_source_file_token1,
+    ACTIONS(46), 1,
+      aux_sym_raw_value_token1,
+    STATE(38), 1,
+      sym_value,
+    ACTIONS(40), 2,
+      anon_sym_true,
+      anon_sym_false,
+    ACTIONS(42), 2,
+      sym_number_literal,
+      sym_color_value,
+    ACTIONS(44), 2,
+      sym_percent_adjustment,
+      sym_numeric_adjustment,
+    STATE(62), 4,
+      sym_boolean_literal,
+      sym_adjustment,
+      sym_string_literal,
+      sym_raw_value,
+  [207] = 5,
     ACTIONS(27), 1,
+      anon_sym_physical,
+    STATE(34), 1,
       sym_key_prefix,
+    ACTIONS(17), 2,
+      sym__snake_case_identifier,
+      aux_sym_key_token1,
     STATE(28), 2,
       sym_key_modifier,
       sym_key,
@@ -3226,7 +3454,67 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_super,
       anon_sym_cmd,
       anon_sym_command,
-  [285] = 2,
+  [233] = 10,
+    ACTIONS(48), 1,
+      ts_builtin_sym_end,
+    ACTIONS(50), 1,
+      aux_sym_source_file_token1,
+    ACTIONS(53), 1,
+      sym_comment,
+    ACTIONS(56), 1,
+      sym__kebab_case_identifier,
+    ACTIONS(59), 1,
+      anon_sym_palette,
+    ACTIONS(62), 1,
+      anon_sym_config_DASHfile,
+    ACTIONS(65), 1,
+      anon_sym_keybind,
+    STATE(40), 1,
+      sym_property,
+    STATE(9), 2,
+      sym_directive,
+      aux_sym_source_file_repeat1,
+    STATE(11), 4,
+      sym_basic_directive,
+      sym_palette_directive,
+      sym_config_file_directive,
+      sym_keybind_directive,
+  [268] = 10,
+    ACTIONS(9), 1,
+      sym__kebab_case_identifier,
+    ACTIONS(11), 1,
+      anon_sym_palette,
+    ACTIONS(13), 1,
+      anon_sym_config_DASHfile,
+    ACTIONS(15), 1,
+      anon_sym_keybind,
+    ACTIONS(68), 1,
+      ts_builtin_sym_end,
+    ACTIONS(70), 1,
+      aux_sym_source_file_token1,
+    ACTIONS(72), 1,
+      sym_comment,
+    STATE(40), 1,
+      sym_property,
+    STATE(9), 2,
+      sym_directive,
+      aux_sym_source_file_repeat1,
+    STATE(11), 4,
+      sym_basic_directive,
+      sym_palette_directive,
+      sym_config_file_directive,
+      sym_keybind_directive,
+  [303] = 2,
+    ACTIONS(74), 2,
+      ts_builtin_sym_end,
+      aux_sym_source_file_token1,
+    ACTIONS(76), 5,
+      sym_comment,
+      sym__kebab_case_identifier,
+      anon_sym_palette,
+      anon_sym_config_DASHfile,
+      anon_sym_keybind,
+  [315] = 2,
     ACTIONS(78), 2,
       ts_builtin_sym_end,
       aux_sym_source_file_token1,
@@ -3236,7 +3524,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_palette,
       anon_sym_config_DASHfile,
       anon_sym_keybind,
-  [297] = 2,
+  [327] = 2,
     ACTIONS(82), 2,
       ts_builtin_sym_end,
       aux_sym_source_file_token1,
@@ -3246,7 +3534,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_palette,
       anon_sym_config_DASHfile,
       anon_sym_keybind,
-  [309] = 2,
+  [339] = 2,
     ACTIONS(86), 2,
       ts_builtin_sym_end,
       aux_sym_source_file_token1,
@@ -3256,7 +3544,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_palette,
       anon_sym_config_DASHfile,
       anon_sym_keybind,
-  [321] = 2,
+  [351] = 2,
     ACTIONS(90), 2,
       ts_builtin_sym_end,
       aux_sym_source_file_token1,
@@ -3266,7 +3554,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_palette,
       anon_sym_config_DASHfile,
       anon_sym_keybind,
-  [333] = 2,
+  [363] = 2,
     ACTIONS(94), 2,
       ts_builtin_sym_end,
       aux_sym_source_file_token1,
@@ -3276,7 +3564,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_palette,
       anon_sym_config_DASHfile,
       anon_sym_keybind,
-  [345] = 2,
+  [375] = 2,
     ACTIONS(98), 2,
       ts_builtin_sym_end,
       aux_sym_source_file_token1,
@@ -3286,385 +3574,380 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_palette,
       anon_sym_config_DASHfile,
       anon_sym_keybind,
-  [357] = 2,
-    ACTIONS(102), 2,
-      ts_builtin_sym_end,
-      aux_sym_source_file_token1,
-    ACTIONS(104), 5,
-      sym_comment,
-      sym__kebab_case_identifier,
-      anon_sym_palette,
-      anon_sym_config_DASHfile,
-      anon_sym_keybind,
-  [369] = 3,
-    ACTIONS(108), 1,
+  [387] = 3,
+    ACTIONS(104), 1,
       anon_sym_PLUS,
     STATE(19), 1,
+      aux_sym_chord_repeat1,
+    ACTIONS(102), 2,
+      anon_sym_EQ2,
+      anon_sym_GT,
+  [398] = 3,
+    ACTIONS(104), 1,
+      anon_sym_PLUS,
+    STATE(20), 1,
       aux_sym_chord_repeat1,
     ACTIONS(106), 2,
       anon_sym_EQ2,
       anon_sym_GT,
-  [380] = 3,
-    ACTIONS(108), 1,
+  [409] = 3,
+    ACTIONS(110), 1,
       anon_sym_PLUS,
     STATE(20), 1,
       aux_sym_chord_repeat1,
-    ACTIONS(110), 2,
+    ACTIONS(108), 2,
       anon_sym_EQ2,
       anon_sym_GT,
-  [391] = 3,
-    ACTIONS(114), 1,
+  [420] = 3,
+    ACTIONS(113), 1,
+      aux_sym_source_file_token1,
+    ACTIONS(115), 1,
+      aux_sym_palette_value_token1,
+    STATE(44), 1,
+      sym_palette_value,
+  [430] = 1,
+    ACTIONS(117), 3,
+      anon_sym_EQ2,
+      anon_sym_GT,
       anon_sym_PLUS,
-    STATE(20), 1,
-      aux_sym_chord_repeat1,
-    ACTIONS(112), 2,
+  [436] = 1,
+    ACTIONS(119), 3,
       anon_sym_EQ2,
       anon_sym_GT,
-  [402] = 3,
-    ACTIONS(117), 1,
+      anon_sym_PLUS,
+  [442] = 3,
+    ACTIONS(121), 1,
       anon_sym_EQ2,
-    ACTIONS(119), 1,
+    ACTIONS(123), 1,
       anon_sym_GT,
-    STATE(24), 1,
+    STATE(25), 1,
       aux_sym_keybind_trigger_repeat1,
-  [412] = 1,
-    ACTIONS(121), 3,
-      anon_sym_EQ2,
-      anon_sym_GT,
-      anon_sym_PLUS,
-  [418] = 1,
-    ACTIONS(123), 3,
-      anon_sym_EQ2,
-      anon_sym_GT,
-      anon_sym_PLUS,
-  [424] = 3,
-    ACTIONS(119), 1,
+  [452] = 3,
+    ACTIONS(123), 1,
       anon_sym_GT,
     ACTIONS(125), 1,
       anon_sym_EQ2,
-    STATE(25), 1,
+    STATE(27), 1,
       aux_sym_keybind_trigger_repeat1,
-  [434] = 3,
-    ACTIONS(127), 1,
+  [462] = 1,
+    ACTIONS(127), 3,
       anon_sym_EQ2,
+      anon_sym_GT,
+      anon_sym_PLUS,
+  [468] = 3,
     ACTIONS(129), 1,
+      anon_sym_EQ2,
+    ACTIONS(131), 1,
       anon_sym_GT,
-    STATE(25), 1,
+    STATE(27), 1,
       aux_sym_keybind_trigger_repeat1,
-  [444] = 3,
-    ACTIONS(132), 1,
-      aux_sym_source_file_token1,
+  [478] = 1,
+    ACTIONS(108), 3,
+      anon_sym_EQ2,
+      anon_sym_GT,
+      anon_sym_PLUS,
+  [484] = 1,
+    ACTIONS(129), 2,
+      anon_sym_EQ2,
+      anon_sym_GT,
+  [489] = 2,
     ACTIONS(134), 1,
-      aux_sym_palette_value_token1,
-    STATE(56), 1,
-      sym_palette_value,
-  [454] = 1,
-    ACTIONS(136), 3,
-      anon_sym_EQ2,
-      anon_sym_GT,
-      anon_sym_PLUS,
-  [460] = 1,
-    ACTIONS(112), 3,
-      anon_sym_EQ2,
-      anon_sym_GT,
-      anon_sym_PLUS,
-  [466] = 2,
-    ACTIONS(138), 1,
       aux_sym_raw_value_token1,
-    STATE(66), 1,
+    STATE(67), 1,
       sym_raw_value,
-  [473] = 2,
-    ACTIONS(140), 1,
+  [496] = 1,
+    ACTIONS(136), 2,
       sym__snake_case_identifier,
-    STATE(58), 1,
+      aux_sym_key_token1,
+  [501] = 2,
+    ACTIONS(138), 1,
+      sym__snake_case_identifier,
+    STATE(59), 1,
       sym_keybind_action,
-  [480] = 2,
-    ACTIONS(142), 1,
+  [508] = 2,
+    ACTIONS(140), 1,
       aux_sym_source_file_token1,
-    ACTIONS(144), 1,
+    ACTIONS(142), 1,
       anon_sym_COLON,
-  [487] = 1,
-    ACTIONS(127), 2,
-      anon_sym_EQ2,
-      anon_sym_GT,
-  [492] = 2,
+  [515] = 1,
+    ACTIONS(144), 2,
+      sym__snake_case_identifier,
+      aux_sym_key_token1,
+  [520] = 2,
+    ACTIONS(138), 1,
+      sym__snake_case_identifier,
+    STATE(66), 1,
+      sym_keybind_action,
+  [527] = 2,
     ACTIONS(146), 1,
       aux_sym_raw_value_token1,
-    STATE(60), 1,
+    STATE(47), 1,
       sym_path_value,
-  [499] = 2,
-    ACTIONS(140), 1,
-      sym__snake_case_identifier,
-    STATE(65), 1,
-      sym_keybind_action,
-  [506] = 1,
-    ACTIONS(148), 1,
-      aux_sym_source_file_token1,
-  [510] = 1,
-    ACTIONS(150), 1,
-      anon_sym_EQ,
-  [514] = 1,
-    ACTIONS(152), 1,
-      aux_sym_source_file_token1,
-  [518] = 1,
-    ACTIONS(154), 1,
-      aux_sym_palette_value_token2,
-  [522] = 1,
-    ACTIONS(156), 1,
-      ts_builtin_sym_end,
-  [526] = 1,
-    ACTIONS(158), 1,
-      aux_sym_string_literal_token1,
-  [530] = 1,
-    ACTIONS(160), 1,
-      anon_sym_DQUOTE,
   [534] = 1,
-    ACTIONS(160), 1,
-      anon_sym_SQUOTE,
+    ACTIONS(148), 1,
+      anon_sym_EQ,
   [538] = 1,
-    ACTIONS(162), 1,
-      anon_sym_EQ,
-  [542] = 1,
-    ACTIONS(164), 1,
-      sym__snake_case_identifier,
-  [546] = 1,
-    ACTIONS(166), 1,
-      aux_sym_string_literal_token2,
-  [550] = 1,
-    ACTIONS(168), 1,
+    ACTIONS(150), 1,
       aux_sym_source_file_token1,
-  [554] = 1,
-    ACTIONS(170), 1,
+  [542] = 1,
+    ACTIONS(152), 1,
+      aux_sym_palette_value_token2,
+  [546] = 1,
+    ACTIONS(154), 1,
       anon_sym_EQ,
+  [550] = 1,
+    ACTIONS(156), 1,
+      anon_sym_EQ2,
+  [554] = 1,
+    ACTIONS(158), 1,
+      anon_sym_DQUOTE,
   [558] = 1,
-    ACTIONS(172), 1,
-      anon_sym_COLON,
+    ACTIONS(158), 1,
+      anon_sym_SQUOTE,
   [562] = 1,
-    ACTIONS(174), 1,
-      anon_sym_COLON,
+    ACTIONS(160), 1,
+      aux_sym_source_file_token1,
   [566] = 1,
-    ACTIONS(176), 1,
-      anon_sym_EQ2,
+    ACTIONS(162), 1,
+      ts_builtin_sym_end,
   [570] = 1,
-    ACTIONS(178), 1,
-      anon_sym_EQ2,
+    ACTIONS(164), 1,
+      aux_sym_source_file_token1,
   [574] = 1,
-    ACTIONS(180), 1,
+    ACTIONS(166), 1,
       aux_sym_source_file_token1,
   [578] = 1,
-    ACTIONS(182), 1,
-      anon_sym_EQ2,
+    ACTIONS(168), 1,
+      anon_sym_EQ,
   [582] = 1,
-    ACTIONS(184), 1,
-      aux_sym_source_file_token1,
+    ACTIONS(170), 1,
+      anon_sym_EQ,
   [586] = 1,
-    ACTIONS(186), 1,
-      aux_sym_source_file_token1,
+    ACTIONS(172), 1,
+      aux_sym_string_literal_token1,
   [590] = 1,
-    ACTIONS(188), 1,
-      aux_sym_source_file_token1,
+    ACTIONS(174), 1,
+      aux_sym_string_literal_token2,
   [594] = 1,
-    ACTIONS(190), 1,
+    ACTIONS(176), 1,
       aux_sym_source_file_token1,
   [598] = 1,
-    ACTIONS(192), 1,
-      aux_sym_source_file_token1,
+    ACTIONS(178), 1,
+      anon_sym_EQ2,
   [602] = 1,
-    ACTIONS(194), 1,
-      anon_sym_EQ,
+    ACTIONS(180), 1,
+      anon_sym_COLON,
   [606] = 1,
-    ACTIONS(196), 1,
-      aux_sym_source_file_token1,
+    ACTIONS(182), 1,
+      anon_sym_COLON,
   [610] = 1,
-    ACTIONS(198), 1,
+    ACTIONS(184), 1,
       aux_sym_source_file_token1,
   [614] = 1,
-    ACTIONS(200), 1,
+    ACTIONS(186), 1,
       aux_sym_source_file_token1,
   [618] = 1,
-    ACTIONS(202), 1,
+    ACTIONS(188), 1,
       aux_sym_source_file_token1,
   [622] = 1,
-    ACTIONS(204), 1,
-      anon_sym_EQ,
-  [626] = 1,
-    ACTIONS(206), 1,
+    ACTIONS(190), 1,
       aux_sym_source_file_token1,
+  [626] = 1,
+    ACTIONS(192), 1,
+      anon_sym_EQ,
   [630] = 1,
-    ACTIONS(208), 1,
+    ACTIONS(194), 1,
+      aux_sym_source_file_token1,
+  [634] = 1,
+    ACTIONS(196), 1,
+      aux_sym_source_file_token1,
+  [638] = 1,
+    ACTIONS(198), 1,
+      anon_sym_EQ2,
+  [642] = 1,
+    ACTIONS(200), 1,
+      aux_sym_source_file_token1,
+  [646] = 1,
+    ACTIONS(202), 1,
+      aux_sym_source_file_token1,
+  [650] = 1,
+    ACTIONS(204), 1,
+      aux_sym_source_file_token1,
+  [654] = 1,
+    ACTIONS(206), 1,
       aux_sym_source_file_token1,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(2)] = 0,
-  [SMALL_STATE(3)] = 54,
-  [SMALL_STATE(4)] = 92,
-  [SMALL_STATE(5)] = 116,
-  [SMALL_STATE(6)] = 150,
-  [SMALL_STATE(7)] = 168,
-  [SMALL_STATE(8)] = 203,
-  [SMALL_STATE(9)] = 238,
-  [SMALL_STATE(10)] = 263,
-  [SMALL_STATE(11)] = 285,
-  [SMALL_STATE(12)] = 297,
-  [SMALL_STATE(13)] = 309,
-  [SMALL_STATE(14)] = 321,
-  [SMALL_STATE(15)] = 333,
-  [SMALL_STATE(16)] = 345,
-  [SMALL_STATE(17)] = 357,
-  [SMALL_STATE(18)] = 369,
-  [SMALL_STATE(19)] = 380,
-  [SMALL_STATE(20)] = 391,
-  [SMALL_STATE(21)] = 402,
-  [SMALL_STATE(22)] = 412,
-  [SMALL_STATE(23)] = 418,
-  [SMALL_STATE(24)] = 424,
-  [SMALL_STATE(25)] = 434,
-  [SMALL_STATE(26)] = 444,
-  [SMALL_STATE(27)] = 454,
-  [SMALL_STATE(28)] = 460,
-  [SMALL_STATE(29)] = 466,
-  [SMALL_STATE(30)] = 473,
-  [SMALL_STATE(31)] = 480,
-  [SMALL_STATE(32)] = 487,
-  [SMALL_STATE(33)] = 492,
-  [SMALL_STATE(34)] = 499,
-  [SMALL_STATE(35)] = 506,
-  [SMALL_STATE(36)] = 510,
-  [SMALL_STATE(37)] = 514,
-  [SMALL_STATE(38)] = 518,
-  [SMALL_STATE(39)] = 522,
-  [SMALL_STATE(40)] = 526,
-  [SMALL_STATE(41)] = 530,
-  [SMALL_STATE(42)] = 534,
-  [SMALL_STATE(43)] = 538,
-  [SMALL_STATE(44)] = 542,
-  [SMALL_STATE(45)] = 546,
-  [SMALL_STATE(46)] = 550,
-  [SMALL_STATE(47)] = 554,
-  [SMALL_STATE(48)] = 558,
-  [SMALL_STATE(49)] = 562,
-  [SMALL_STATE(50)] = 566,
-  [SMALL_STATE(51)] = 570,
-  [SMALL_STATE(52)] = 574,
-  [SMALL_STATE(53)] = 578,
-  [SMALL_STATE(54)] = 582,
-  [SMALL_STATE(55)] = 586,
-  [SMALL_STATE(56)] = 590,
-  [SMALL_STATE(57)] = 594,
-  [SMALL_STATE(58)] = 598,
-  [SMALL_STATE(59)] = 602,
-  [SMALL_STATE(60)] = 606,
-  [SMALL_STATE(61)] = 610,
-  [SMALL_STATE(62)] = 614,
-  [SMALL_STATE(63)] = 618,
-  [SMALL_STATE(64)] = 622,
-  [SMALL_STATE(65)] = 626,
-  [SMALL_STATE(66)] = 630,
+  [SMALL_STATE(3)] = 58,
+  [SMALL_STATE(4)] = 100,
+  [SMALL_STATE(5)] = 125,
+  [SMALL_STATE(6)] = 154,
+  [SMALL_STATE(7)] = 173,
+  [SMALL_STATE(8)] = 207,
+  [SMALL_STATE(9)] = 233,
+  [SMALL_STATE(10)] = 268,
+  [SMALL_STATE(11)] = 303,
+  [SMALL_STATE(12)] = 315,
+  [SMALL_STATE(13)] = 327,
+  [SMALL_STATE(14)] = 339,
+  [SMALL_STATE(15)] = 351,
+  [SMALL_STATE(16)] = 363,
+  [SMALL_STATE(17)] = 375,
+  [SMALL_STATE(18)] = 387,
+  [SMALL_STATE(19)] = 398,
+  [SMALL_STATE(20)] = 409,
+  [SMALL_STATE(21)] = 420,
+  [SMALL_STATE(22)] = 430,
+  [SMALL_STATE(23)] = 436,
+  [SMALL_STATE(24)] = 442,
+  [SMALL_STATE(25)] = 452,
+  [SMALL_STATE(26)] = 462,
+  [SMALL_STATE(27)] = 468,
+  [SMALL_STATE(28)] = 478,
+  [SMALL_STATE(29)] = 484,
+  [SMALL_STATE(30)] = 489,
+  [SMALL_STATE(31)] = 496,
+  [SMALL_STATE(32)] = 501,
+  [SMALL_STATE(33)] = 508,
+  [SMALL_STATE(34)] = 515,
+  [SMALL_STATE(35)] = 520,
+  [SMALL_STATE(36)] = 527,
+  [SMALL_STATE(37)] = 534,
+  [SMALL_STATE(38)] = 538,
+  [SMALL_STATE(39)] = 542,
+  [SMALL_STATE(40)] = 546,
+  [SMALL_STATE(41)] = 550,
+  [SMALL_STATE(42)] = 554,
+  [SMALL_STATE(43)] = 558,
+  [SMALL_STATE(44)] = 562,
+  [SMALL_STATE(45)] = 566,
+  [SMALL_STATE(46)] = 570,
+  [SMALL_STATE(47)] = 574,
+  [SMALL_STATE(48)] = 578,
+  [SMALL_STATE(49)] = 582,
+  [SMALL_STATE(50)] = 586,
+  [SMALL_STATE(51)] = 590,
+  [SMALL_STATE(52)] = 594,
+  [SMALL_STATE(53)] = 598,
+  [SMALL_STATE(54)] = 602,
+  [SMALL_STATE(55)] = 606,
+  [SMALL_STATE(56)] = 610,
+  [SMALL_STATE(57)] = 614,
+  [SMALL_STATE(58)] = 618,
+  [SMALL_STATE(59)] = 622,
+  [SMALL_STATE(60)] = 626,
+  [SMALL_STATE(61)] = 630,
+  [SMALL_STATE(62)] = 634,
+  [SMALL_STATE(63)] = 638,
+  [SMALL_STATE(64)] = 642,
+  [SMALL_STATE(65)] = 646,
+  [SMALL_STATE(66)] = 650,
+  [SMALL_STATE(67)] = 654,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 0, 0, 0),
-  [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
-  [7] = {.entry = {.count = 1, .reusable = false}}, SHIFT(8),
-  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(59),
-  [11] = {.entry = {.count = 1, .reusable = false}}, SHIFT(47),
-  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(64),
-  [15] = {.entry = {.count = 1, .reusable = false}}, SHIFT(36),
-  [17] = {.entry = {.count = 1, .reusable = false}}, SHIFT(22),
-  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
-  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
-  [23] = {.entry = {.count = 1, .reusable = false}}, SHIFT(46),
-  [25] = {.entry = {.count = 1, .reusable = false}}, SHIFT(48),
-  [27] = {.entry = {.count = 1, .reusable = false}}, SHIFT(49),
-  [29] = {.entry = {.count = 1, .reusable = false}}, SHIFT(23),
+  [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
+  [7] = {.entry = {.count = 1, .reusable = false}}, SHIFT(10),
+  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(48),
+  [11] = {.entry = {.count = 1, .reusable = false}}, SHIFT(49),
+  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(60),
+  [15] = {.entry = {.count = 1, .reusable = false}}, SHIFT(37),
+  [17] = {.entry = {.count = 1, .reusable = false}}, SHIFT(23),
+  [19] = {.entry = {.count = 1, .reusable = false}}, SHIFT(50),
+  [21] = {.entry = {.count = 1, .reusable = false}}, SHIFT(51),
+  [23] = {.entry = {.count = 1, .reusable = false}}, SHIFT(52),
+  [25] = {.entry = {.count = 1, .reusable = false}}, SHIFT(54),
+  [27] = {.entry = {.count = 1, .reusable = false}}, SHIFT(55),
+  [29] = {.entry = {.count = 1, .reusable = false}}, SHIFT(22),
   [31] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_keybind_value_repeat1, 2, 0, 0),
-  [33] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_keybind_value_repeat1, 2, 0, 0), SHIFT_REPEAT(48),
-  [36] = {.entry = {.count = 1, .reusable = false}}, SHIFT(15),
-  [38] = {.entry = {.count = 1, .reusable = false}}, SHIFT(61),
-  [40] = {.entry = {.count = 1, .reusable = false}}, SHIFT(62),
-  [42] = {.entry = {.count = 1, .reusable = false}}, SHIFT(40),
-  [44] = {.entry = {.count = 1, .reusable = false}}, SHIFT(45),
-  [46] = {.entry = {.count = 1, .reusable = false}}, SHIFT(63),
-  [48] = {.entry = {.count = 1, .reusable = false}}, SHIFT(35),
-  [50] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keybind_modifier, 2, 0, 5),
-  [52] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0),
-  [54] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(7),
-  [57] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(7),
-  [60] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(59),
-  [63] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(47),
-  [66] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(64),
-  [69] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(36),
-  [72] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 1, 0, 0),
-  [74] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
-  [76] = {.entry = {.count = 1, .reusable = false}}, SHIFT(7),
-  [78] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_directive, 1, 0, 0),
-  [80] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_directive, 1, 0, 0),
-  [82] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_palette_directive, 4, 0, 4),
-  [84] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_palette_directive, 4, 0, 4),
-  [86] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_palette_directive, 3, 0, 1),
-  [88] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_palette_directive, 3, 0, 1),
-  [90] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_config_file_directive, 4, 0, 4),
-  [92] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_config_file_directive, 4, 0, 4),
-  [94] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_basic_directive, 3, 0, 1),
-  [96] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_basic_directive, 3, 0, 1),
-  [98] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keybind_directive, 4, 0, 4),
-  [100] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keybind_directive, 4, 0, 4),
-  [102] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_basic_directive, 4, 0, 4),
-  [104] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_basic_directive, 4, 0, 4),
-  [106] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_chord, 1, 0, 0),
-  [108] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
-  [110] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_chord, 2, 0, 0),
-  [112] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_chord_repeat1, 2, 0, 0),
-  [114] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_chord_repeat1, 2, 0, 0), SHIFT_REPEAT(10),
-  [117] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keybind_trigger, 1, 0, 0),
-  [119] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
-  [121] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_key, 1, 0, 2),
-  [123] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_key_modifier, 1, 0, 0),
+  [33] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_keybind_value_repeat1, 2, 0, 0), SHIFT_REPEAT(54),
+  [36] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keybind_modifier, 2, 0, 5),
+  [38] = {.entry = {.count = 1, .reusable = false}}, SHIFT(13),
+  [40] = {.entry = {.count = 1, .reusable = false}}, SHIFT(58),
+  [42] = {.entry = {.count = 1, .reusable = false}}, SHIFT(62),
+  [44] = {.entry = {.count = 1, .reusable = false}}, SHIFT(64),
+  [46] = {.entry = {.count = 1, .reusable = false}}, SHIFT(65),
+  [48] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0),
+  [50] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(9),
+  [53] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(9),
+  [56] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(48),
+  [59] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(49),
+  [62] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(60),
+  [65] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(37),
+  [68] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 1, 0, 0),
+  [70] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
+  [72] = {.entry = {.count = 1, .reusable = false}}, SHIFT(9),
+  [74] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_directive, 1, 0, 0),
+  [76] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_directive, 1, 0, 0),
+  [78] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_palette_directive, 3, 0, 1),
+  [80] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_palette_directive, 3, 0, 1),
+  [82] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_basic_directive, 3, 0, 1),
+  [84] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_basic_directive, 3, 0, 1),
+  [86] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_config_file_directive, 4, 0, 4),
+  [88] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_config_file_directive, 4, 0, 4),
+  [90] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keybind_directive, 4, 0, 4),
+  [92] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keybind_directive, 4, 0, 4),
+  [94] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_palette_directive, 4, 0, 4),
+  [96] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_palette_directive, 4, 0, 4),
+  [98] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_basic_directive, 4, 0, 4),
+  [100] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_basic_directive, 4, 0, 4),
+  [102] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_chord, 1, 0, 0),
+  [104] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
+  [106] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_chord, 2, 0, 0),
+  [108] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_chord_repeat1, 2, 0, 0),
+  [110] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_chord_repeat1, 2, 0, 0), SHIFT_REPEAT(8),
+  [113] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
+  [115] = {.entry = {.count = 1, .reusable = false}}, SHIFT(41),
+  [117] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_key_modifier, 1, 0, 0),
+  [119] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_key, 1, 0, 2),
+  [121] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keybind_trigger, 1, 0, 0),
+  [123] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
   [125] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keybind_trigger, 2, 0, 0),
-  [127] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_keybind_trigger_repeat1, 2, 0, 0),
-  [129] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_keybind_trigger_repeat1, 2, 0, 0), SHIFT_REPEAT(9),
-  [132] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
-  [134] = {.entry = {.count = 1, .reusable = false}}, SHIFT(50),
-  [136] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_key, 3, 0, 6),
-  [138] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
-  [140] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
-  [142] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keybind_action, 1, 0, 7),
-  [144] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
-  [146] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
-  [148] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_raw_value, 1, 0, 0),
-  [150] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
-  [152] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
-  [154] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
-  [156] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [158] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
-  [160] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
-  [162] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
-  [164] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
-  [166] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
-  [168] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__keybind_value, 1, 0, 3),
-  [170] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
-  [172] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
-  [174] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
-  [176] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
-  [178] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
-  [180] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
-  [182] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
+  [127] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_key, 2, 0, 7),
+  [129] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_keybind_trigger_repeat1, 2, 0, 0),
+  [131] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_keybind_trigger_repeat1, 2, 0, 0), SHIFT_REPEAT(5),
+  [134] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
+  [136] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_key_prefix, 2, 0, 6),
+  [138] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
+  [140] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keybind_action, 1, 0, 8),
+  [142] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
+  [144] = {.entry = {.count = 1, .reusable = false}}, SHIFT(26),
+  [146] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
+  [148] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
+  [150] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
+  [152] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
+  [154] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
+  [156] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
+  [158] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
+  [160] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
+  [162] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [164] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_path_value, 1, 0, 0),
+  [166] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
+  [168] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 1, 0, 0),
+  [170] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
+  [172] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
+  [174] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
+  [176] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__keybind_value, 1, 0, 3),
+  [178] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
+  [180] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
+  [182] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
   [184] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_palette_value, 3, 0, 0),
   [186] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string_literal, 3, 0, 0),
-  [188] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
-  [190] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_path_value, 1, 0, 0),
-  [192] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keybind_value, 3, 0, 8),
-  [194] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 1, 0, 0),
-  [196] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
-  [198] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_boolean_literal, 1, 0, 0),
-  [200] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_value, 1, 0, 0),
-  [202] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_adjustment, 1, 0, 0),
-  [204] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
-  [206] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keybind_value, 4, 0, 9),
-  [208] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keybind_action, 3, 0, 10),
+  [188] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_boolean_literal, 1, 0, 0),
+  [190] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keybind_value, 3, 0, 9),
+  [192] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
+  [194] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
+  [196] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_value, 1, 0, 0),
+  [198] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
+  [200] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_adjustment, 1, 0, 0),
+  [202] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_raw_value, 1, 0, 0),
+  [204] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keybind_value, 4, 0, 10),
+  [206] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keybind_action, 3, 0, 11),
 };
 
 #ifdef __cplusplus

--- a/src/tree_sitter/array.h
+++ b/src/tree_sitter/array.h
@@ -14,6 +14,7 @@ extern "C" {
 #include <string.h>
 
 #ifdef _MSC_VER
+#pragma warning(push)
 #pragma warning(disable : 4101)
 #elif defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
@@ -278,7 +279,7 @@ static inline void _array__splice(Array *self, size_t element_size,
 #define _compare_int(a, b) ((int)*(a) - (int)(b))
 
 #ifdef _MSC_VER
-#pragma warning(default : 4101)
+#pragma warning(pop)
 #elif defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif

--- a/test/config
+++ b/test/config
@@ -55,6 +55,8 @@ macos-icon-screen-color = 202020
 config-file = ~/.config/ghostty/theme
 
 # keybind = cmd+shift+a=toggle
-keybind = all:global:cmd+c=hello:A B
+keybind = all:global:cmd+c=hello:a,b
+keybind = all:global:cmd+physical:c+b=hello:a,10
+keybind = all:global:cmd+physical:c+b>s+b=hello:a,10
 #keybind = cmd+shift+opt+p=hello_world:loudly
 # keybind = unconsumed:cmd+shift+opt+p=hello

--- a/test/corpus/config-file-directives.txt
+++ b/test/corpus/config-file-directives.txt
@@ -10,7 +10,7 @@ config-file = ~/.config/ghostty/config.d/theme
  (directive
   (config_file_directive
    (property)
-   (raw_value))))
+   (path_value))))
 
 ==============================
 Config File Directive - Quoted
@@ -25,11 +25,11 @@ config-file = '~/.config/ghostty/config.d/theme'
  (directive
   (config_file_directive
    (property)
-   (raw_value)))
+   (path_value)))
  (directive
   (config_file_directive
    (property)
-   (raw_value))))
+   (path_value))))
 
 ===================================
 Config File Directive - With Spaces
@@ -43,4 +43,4 @@ config-file = ~/.config/ghostty/config.d/my theme
  (directive
   (config_file_directive
    (property)
-   (raw_value))))
+   (path_value))))

--- a/test/corpus/keybind-directives.txt
+++ b/test/corpus/keybind-directives.txt
@@ -422,6 +422,26 @@ keybind = ctrl+shift+physical:a=foo:BAR
      (action_argument))))))
 
 =====================================
+Keybind Directive - Special Characters
+=====================================
+
+keybind = ctrl+ö=action
+
+---
+
+(source_file
+ (directive
+  (keybind_directive
+   (property)
+   (keybind_value
+    (keybind_trigger
+     (chord
+      (key_modifier)
+      (key)))
+    (keybind_action
+     (action_name))))))
+
+=====================================
 Keybind Directive - Clear Keybinds
 =====================================
 

--- a/test/corpus/keybind-directives.txt
+++ b/test/corpus/keybind-directives.txt
@@ -56,46 +56,186 @@ keybind = ctrl+f12=toggle
 ---
 
 (source_file
- (directive
-  (keybind_directive
-   (property)
-   (keybind_value
-    (keybind_trigger
-     (chord
-      (key_modifier)
-      (key)))
-    (keybind_action
-     (action_name)))))
- (directive
-  (keybind_directive
-   (property)
-   (keybind_value
-    (keybind_trigger
-     (chord
-      (key_modifier)
-      (key)))
-    (keybind_action
-     (action_name)))))
- (directive
-  (keybind_directive
-   (property)
-   (keybind_value
-    (keybind_trigger
-     (chord
-      (key_modifier)
-      (key)))
-    (keybind_action
-     (action_name)))))
- (directive
-  (keybind_directive
-   (property)
-   (keybind_value
-    (keybind_trigger
-     (chord
-      (key_modifier)
-      (key)))
-    (keybind_action
-     (action_name))))))
+      (directive
+        (keybind_directive
+          (property)
+          (keybind_value
+            (keybind_trigger
+              (chord
+                (key_modifier)
+                (key)))
+            (keybind_action
+              (action_name)))))
+      (directive
+        (keybind_directive
+          (property)
+          (keybind_value
+            (keybind_trigger
+              (chord
+                (key_modifier)
+                (key)))
+            (keybind_action
+              (action_name)))))
+      (directive
+        (keybind_directive
+          (property)
+          (keybind_value
+            (keybind_trigger
+              (chord
+                (key_modifier)
+                (key)))
+            (keybind_action
+              (action_name)))))
+      (directive
+        (keybind_directive
+          (property)
+          (keybind_value
+            (keybind_trigger
+              (chord
+                (key_modifier)
+                (key)))
+            (keybind_action
+              (action_name)))))
+      (directive
+        (keybind_directive
+          (property)
+          (keybind_value
+            (keybind_trigger
+              (chord
+                (key_modifier)
+                (key)))
+            (keybind_action
+              (action_name)))))
+      (directive
+        (keybind_directive
+          (property)
+          (keybind_value
+            (keybind_trigger
+              (chord
+                (key_modifier)
+                (key)))
+            (keybind_action
+              (action_name)))))
+      (directive
+        (keybind_directive
+          (property)
+          (keybind_value
+            (keybind_trigger
+              (chord
+                (key_modifier)
+                (key)))
+            (keybind_action
+              (action_name)))))
+      (directive
+        (keybind_directive
+          (property)
+          (keybind_value
+            (keybind_trigger
+              (chord
+                (key_modifier)
+                (key)))
+            (keybind_action
+              (action_name)))))
+      (directive
+        (keybind_directive
+          (property)
+          (keybind_value
+            (keybind_trigger
+              (chord
+                (key_modifier)
+                (key)))
+            (keybind_action
+              (action_name)))))
+      (directive
+        (keybind_directive
+          (property)
+          (keybind_value
+            (keybind_trigger
+              (chord
+                (key_modifier)
+                (key)))
+            (keybind_action
+              (action_name)))))
+      (directive
+        (keybind_directive
+          (property)
+          (keybind_value
+            (keybind_trigger
+              (chord
+                (key_modifier)
+                (key)))
+            (keybind_action
+              (action_name)))))
+      (directive
+        (keybind_directive
+          (property)
+          (keybind_value
+            (keybind_trigger
+              (chord
+                (key_modifier)
+                (key)))
+            (keybind_action
+              (action_name)))))
+      (directive
+        (keybind_directive
+          (property)
+          (keybind_value
+            (keybind_trigger
+              (chord
+                (key_modifier)
+                (key)))
+            (keybind_action
+              (action_name)))))
+      (directive
+        (keybind_directive
+          (property)
+          (keybind_value
+            (keybind_trigger
+              (chord
+                (key_modifier)
+                (key)))
+            (keybind_action
+              (action_name)))))
+      (directive
+        (keybind_directive
+          (property)
+          (keybind_value
+            (keybind_trigger
+              (chord
+                (key_modifier)
+                (key)))
+            (keybind_action
+              (action_name)))))
+      (directive
+        (keybind_directive
+          (property)
+          (keybind_value
+            (keybind_trigger
+              (chord
+                (key_modifier)
+                (key)))
+            (keybind_action
+              (action_name)))))
+      (directive
+        (keybind_directive
+          (property)
+          (keybind_value
+            (keybind_trigger
+              (chord
+                (key_modifier)
+                (key)))
+            (keybind_action
+              (action_name)))))
+      (directive
+        (keybind_directive
+          (property)
+          (keybind_value
+            (keybind_trigger
+              (chord
+                (key_modifier)
+                (key)))
+            (keybind_action
+              (action_name))))))
 
 =====================================
 Keybind Directive - Multiple Triggers
@@ -257,3 +397,45 @@ keybind = ctrl+shift+a=foobar:"A B"
      (action_name)
      (action_argument))))))
 
+
+=====================================
+Keybind Directive - Key Prefix
+=====================================
+
+keybind = ctrl+shift+physical:a=foo:BAR
+
+---
+
+(source_file
+ (directive
+  (keybind_directive
+   (property)
+   (keybind_value
+    (keybind_trigger
+     (chord
+      (key_modifier)
+      (key_modifier)
+      (key 
+       (key_prefix))))
+    (keybind_action
+     (action_name)
+     (action_argument))))))
+
+=====================================
+Keybind Directive - Clear Keybinds
+=====================================
+
+keybind = clear
+keybind = "clear"
+
+---
+
+(source_file
+      (directive
+        (keybind_directive
+          (property)
+          (value)))
+      (directive
+        (keybind_directive
+          (property)
+          (value))))


### PR DESCRIPTION
Hi! Awesome work on this repo! This PR adds support for key prefixes, detailed here: https://ghostty.org/docs/config/reference#keybind
something like:
`keybind = ctrl+physical:a=close_window`
This should also fix parsing the individual arguments for actions:
`keybind = ctrl+physical:a=resize_split:right,10`
would parse the `right`, the `,` and the `10` individually rather than as `raw_value`
