### PR TITLE
feat: support nvim-treesitter rewrite

### DIFF
--- a/plugin/tree-sitter-ghostty.lua
+++ b/plugin/tree-sitter-ghostty.lua
@@ -1,16 +1,25 @@
 
-local _, ok = pcall(require, "nvim-treesitter.parsers")
+local ok, parsers = pcall(require, "nvim-treesitter.parsers")
 if not ok then
   -- nvim-treesitter not found.
   return
 end
+
 
 -- Register the plugin path as a tree-sitter parser to nvim-treesitter.
 -- This is not required, but it allows nvim-treesitter to manage it e.g. :TS{Install,Update} ghostty
 local file = debug.getinfo(1).source:match("@(.*/)")
 local plugin_dir = vim.fn.fnamemodify(file, ":p:h:h")
 
-local parser_configs = require("nvim-treesitter.parsers").get_parser_configs()
+--- @type ParserInfo[]
+local parser_configs
+
+if type(parsers.get_parser_configs) == "function" then
+  parser_configs = parsers.get_parser_configs()
+else
+  -- "nvim-treesitter.parsers" exports the parser table itself starting nvim-treesitter v1.x
+  parser_configs = parsers
+end
 
 parser_configs.ghostty = {
   install_info = {


### PR DESCRIPTION
Looks like `nvim-treesitter` is being rewritten and has breaking changes around `"nvim-treesitter.parsers".get_parser_configs()`.

This change make it so that we adopt the new API. This change I believe should be safe enough that if the API changes again, it doesn't break unlike today.

Addresses https://github.com/bezhermoso/tree-sitter-ghostty/issues/9