### PR TITLE
test(nvim): add plenary test suite and CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,30 @@ on:
       - src/**
       - queries/**
       - test/**
+      - tests/**
       - bindings/**
       - binding.gyp
+      - lua/**
+      - plugin/**
+      - ftdetect/**
+      - ftplugin/**
+      - Makefile
+      - .github/workflows/ci.yml
   pull_request:
     paths:
       - grammar.js
       - src/**
       - queries/**
       - test/**
+      - tests/**
       - bindings/**
       - binding.gyp
+      - lua/**
+      - plugin/**
+      - ftdetect/**
+      - ftplugin/**
+      - Makefile
+      - .github/workflows/ci.yml
 
 concurrency:
   group: ${{github.workflow}}-${{github.ref}}
@@ -49,3 +63,32 @@ jobs:
           test-rust: ${{runner.os == 'Linux'}}
           test-go: ${{runner.os == 'Windows'}}
           test-swift: ${{runner.os == 'macOS'}}
+
+  nvim-test:
+    name: Test Neovim plugin
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up tree-sitter
+        uses: tree-sitter/setup-action@v2
+        with:
+          tree-sitter-ref: v0.26.8
+      - name: Install Neovim
+        uses: rhysd/action-setup-vim@v1
+        with:
+          neovim: true
+          version: stable
+      - name: Checkout plenary.nvim
+        uses: actions/checkout@v4
+        with:
+          repository: nvim-lua/plenary.nvim
+          path: .deps/plenary.nvim
+      - name: Build parser
+        run: make nvim_install
+      - name: Run plugin tests
+        env:
+          PLENARY_PATH: ${{ github.workspace }}/.deps/plenary.nvim
+        run: |
+          nvim --headless --noplugin -u tests/nvim/minimal_init.lua \
+            -c "PlenaryBustedDirectory tests/nvim {minimal_init='tests/nvim/minimal_init.lua'}"

--- a/Makefile
+++ b/Makefile
@@ -96,5 +96,12 @@ nvim_install:
 	mkdir -p parser
 	$(TS) build -o parser/ghostty.so
 
-.PHONY: all install uninstall clean test nvim_install
+# Run the Neovim plugin test suite (plenary.nvim, busted-style).
+# Set PLENARY_PATH to override the plenary lookup; otherwise common locations
+# under ~/.local/share/nvim or .deps/plenary.nvim are tried.
+nvim_test: nvim_install
+	nvim --headless --noplugin -u tests/nvim/minimal_init.lua \
+		-c "PlenaryBustedDirectory tests/nvim {minimal_init='tests/nvim/minimal_init.lua'}"
+
+.PHONY: all install uninstall clean test nvim_install nvim_test
 

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,22 @@
+# `test/` — tree-sitter grammar tests
+
+Tests for the **tree-sitter grammar itself**, exercised by the `tree-sitter`
+CLI. Not related to the Neovim plugin — see [`tests/`](../tests/) for that.
+
+## Layout
+
+- `corpus/` — parser corpus tests. Each `.txt` file contains one or more
+  `===`-delimited cases pairing a Ghostty config snippet with its expected
+  syntax tree. Read by `tree-sitter test`.
+- `config` — a representative Ghostty configuration used as a real-world
+  fixture. Useful for ad-hoc parses and visual checks.
+
+## Running
+
+```sh
+make test            # → tree-sitter test
+tree-sitter test     # equivalent
+```
+
+In CI these are run by `tree-sitter/parser-test-action@v3` across Linux,
+Windows, and macOS — see `.github/workflows/ci.yml`.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,44 @@
+# `tests/` — Neovim plugin tests
+
+Tests for the **Neovim plugin integration** (filetype detection, ftplugin,
+parser registration, `:checkhealth`), written with [plenary.nvim]'s busted-style
+runner. Not related to the tree-sitter grammar — see [`test/`](../test/) for
+that.
+
+## Layout
+
+- `nvim/minimal_init.lua` — bootstraps `runtimepath` with this plugin and
+  plenary, then sources `ftdetect/*`.
+- `nvim/filetype_spec.lua` — confirms `ftdetect/ghostty.vim` claims the right
+  paths and ignores unrelated ones.
+- `nvim/ftplugin_spec.lua` — confirms `commentstring` is set and a tree-sitter
+  parser attaches to a `ghostty` buffer.
+- `nvim/parser_registration_spec.lua` — exercises
+  `tree-sitter-ghostty.register_parser()` against four scenarios (no
+  nvim-treesitter, v0.x via `get_parser_configs()`, v1.x parsers-as-config,
+  existing-registration no-overwrite).
+- `nvim/health_spec.lua` — captures `vim.health.*` calls and asserts the
+  `:checkhealth tree-sitter-ghostty` output for healthy and stubbed-degraded
+  environments.
+
+## Running
+
+The parser binary must be built first; the `nvim_test` target handles it:
+
+```sh
+make nvim_test
+```
+
+To override plenary discovery, set `PLENARY_PATH`:
+
+```sh
+PLENARY_PATH=/path/to/plenary.nvim make nvim_test
+```
+
+Otherwise the runner looks at `.deps/plenary.nvim`, then common local install
+paths under `~/.local/share/nvim`.
+
+In CI these are run by the `nvim-test` job on Ubuntu — see
+`.github/workflows/ci.yml`.
+
+[plenary.nvim]: https://github.com/nvim-lua/plenary.nvim

--- a/tests/nvim/filetype_spec.lua
+++ b/tests/nvim/filetype_spec.lua
@@ -1,0 +1,23 @@
+describe("ftdetect/ghostty", function()
+    local function ft_for(path)
+        vim.cmd("silent! bwipeout!")
+        vim.cmd("silent edit " .. vim.fn.fnameescape(path))
+        return vim.bo.filetype
+    end
+
+    it("matches ~/.config/ghostty/config", function()
+        assert.are.equal("ghostty", ft_for("/tmp/test/ghostty/config"))
+    end)
+
+    it("matches files inside ghostty/themes/", function()
+        assert.are.equal("ghostty", ft_for("/tmp/test/ghostty/themes/my-theme"))
+    end)
+
+    it("matches ghostty/config-foo (suffixed config)", function()
+        assert.are.equal("ghostty", ft_for("/tmp/test/ghostty/config-local"))
+    end)
+
+    it("does not claim unrelated paths", function()
+        assert.are_not.equal("ghostty", ft_for("/tmp/test/some/random.txt"))
+    end)
+end)

--- a/tests/nvim/ftplugin_spec.lua
+++ b/tests/nvim/ftplugin_spec.lua
@@ -1,0 +1,18 @@
+describe("ftplugin/ghostty", function()
+    before_each(function()
+        vim.cmd("silent! bwipeout!")
+        vim.cmd("enew")
+    end)
+
+    it("sets the comment string", function()
+        vim.bo.filetype = "ghostty"
+        assert.are.equal("# %s", vim.bo.commentstring)
+    end)
+
+    it("attaches a tree-sitter parser to the buffer", function()
+        vim.bo.filetype = "ghostty"
+        local ok, parser = pcall(vim.treesitter.get_parser, 0, "ghostty")
+        assert.is_true(ok, tostring(parser))
+        assert.is_not_nil(parser)
+    end)
+end)

--- a/tests/nvim/health_spec.lua
+++ b/tests/nvim/health_spec.lua
@@ -1,0 +1,119 @@
+describe("tree-sitter-ghostty.health.check", function()
+    local original_health
+    local captured
+
+    local function make_stub()
+        captured = { start = {}, ok = {}, warn = {}, error = {}, info = {} }
+        local stub = {
+            start = function(name) table.insert(captured.start, name) end,
+            ok = function(msg) table.insert(captured.ok, msg) end,
+            warn = function(msg, advice)
+                table.insert(captured.warn, { msg = msg, advice = advice })
+            end,
+            error = function(msg, advice)
+                table.insert(captured.error, { msg = msg, advice = advice })
+            end,
+            info = function(msg) table.insert(captured.info, msg) end,
+        }
+        stub.report_start = stub.start
+        stub.report_ok = stub.ok
+        stub.report_warn = stub.warn
+        stub.report_error = stub.error
+        stub.report_info = stub.info
+        return stub
+    end
+
+    local function run_check()
+        package.loaded["tree-sitter-ghostty.health"] = nil
+        require("tree-sitter-ghostty.health").check()
+    end
+
+    local function find(list, pattern)
+        for _, entry in ipairs(list) do
+            local msg = type(entry) == "string" and entry or entry.msg
+            if msg:match(pattern) then return entry end
+        end
+        return nil
+    end
+
+    before_each(function()
+        original_health = vim.health
+        vim.health = make_stub()
+    end)
+
+    after_each(function()
+        vim.health = original_health
+        package.loaded["tree-sitter-ghostty.health"] = nil
+    end)
+
+    it("emits a section start", function()
+        run_check()
+        assert.are.same({ "tree-sitter-ghostty" }, captured.start)
+    end)
+
+    it("emits no errors against a healthy tree", function()
+        run_check()
+        assert.are.equal(0, #captured.error,
+            "unexpected health errors: " .. vim.inspect(captured.error))
+    end)
+
+    it("reports the parser as loadable", function()
+        run_check()
+        assert.is_not_nil(find(captured.ok, "Parser `ghostty` loads"))
+    end)
+
+    it("reports the highlight query as found", function()
+        run_check()
+        assert.is_not_nil(find(captured.ok, "Highlight query found"))
+    end)
+
+    it("reports filetype detection as registered", function()
+        run_check()
+        assert.is_not_nil(find(captured.ok, "Filetype detection registered"))
+    end)
+
+    it("warns when tree-sitter CLI is older than 0.26", function()
+        local original_executable = vim.fn.executable
+        local original_system = vim.fn.system
+        vim.fn.executable = function(name)
+            if name == "tree-sitter" then return 1 end
+            return original_executable(name)
+        end
+        vim.fn.system = function(cmd)
+            if type(cmd) == "table" and cmd[1] == "tree-sitter" then
+                return "tree-sitter 0.24.7\n"
+            end
+            return original_system(cmd)
+        end
+
+        local ok, err = pcall(run_check)
+        vim.fn.executable = original_executable
+        vim.fn.system = original_system
+        assert.is_true(ok, tostring(err))
+
+        assert.is_not_nil(find(captured.warn, "older than 0.26"))
+    end)
+
+    it("reports tree-sitter CLI 0.26+ as ok", function()
+        local original_executable = vim.fn.executable
+        local original_system = vim.fn.system
+        vim.fn.executable = function(name)
+            if name == "tree-sitter" then return 1 end
+            return original_executable(name)
+        end
+        vim.fn.system = function(cmd)
+            if type(cmd) == "table" and cmd[1] == "tree-sitter" then
+                return "tree-sitter 0.26.8\n"
+            end
+            return original_system(cmd)
+        end
+
+        local ok, err = pcall(run_check)
+        vim.fn.executable = original_executable
+        vim.fn.system = original_system
+        assert.is_true(ok, tostring(err))
+
+        assert.is_not_nil(find(captured.ok, "tree%-sitter CLI"))
+        assert.is_nil(find(captured.warn, "older than 0.26"))
+    end)
+end)

--- a/tests/nvim/minimal_init.lua
+++ b/tests/nvim/minimal_init.lua
@@ -1,0 +1,42 @@
+-- Minimal init for plenary.nvim test runs.
+-- Usage:
+--   nvim --headless --noplugin -u tests/nvim/minimal_init.lua \
+--     -c "PlenaryBustedDirectory tests/nvim {minimal_init='tests/nvim/minimal_init.lua'}"
+
+local function plugin_root()
+    local file = debug.getinfo(1, "S").source:sub(2)
+    return vim.fn.fnamemodify(file, ":p:h:h:h")
+end
+
+local root = plugin_root()
+vim.opt.runtimepath:prepend(root)
+
+local function find_plenary()
+    local explicit = os.getenv("PLENARY_PATH")
+    if explicit and explicit ~= "" and vim.fn.isdirectory(explicit) == 1 then
+        return explicit
+    end
+    local candidates = {
+        root .. "/.deps/plenary.nvim",
+        vim.fn.expand("~/.local/share/nvim/site/pack/vendor/start/plenary.nvim"),
+        vim.fn.expand("~/.local/share/nvim/lazy/plenary.nvim"),
+    }
+    for _, dir in ipairs(candidates) do
+        if vim.fn.isdirectory(dir) == 1 then
+            return dir
+        end
+    end
+    return nil
+end
+
+local plenary = find_plenary()
+if not plenary then
+    io.stderr:write("ERROR: plenary.nvim not found. Set PLENARY_PATH or clone into .deps/plenary.nvim\n")
+    os.exit(1)
+end
+vim.opt.runtimepath:prepend(plenary)
+
+vim.cmd("runtime plugin/plenary.vim")
+vim.cmd("filetype plugin on")
+vim.cmd("runtime! ftdetect/*.vim")
+vim.cmd("runtime! ftdetect/*.lua")

--- a/tests/nvim/parser_registration_spec.lua
+++ b/tests/nvim/parser_registration_spec.lua
@@ -1,0 +1,51 @@
+describe("tree-sitter-ghostty.register_parser", function()
+    local saved
+
+    before_each(function()
+        saved = package.loaded["nvim-treesitter.parsers"]
+        package.loaded["nvim-treesitter.parsers"] = nil
+    end)
+
+    after_each(function()
+        package.loaded["nvim-treesitter.parsers"] = saved
+    end)
+
+    it("is a no-op when nvim-treesitter is not installed", function()
+        local ok, err = pcall(function()
+            require("tree-sitter-ghostty").register_parser()
+        end)
+        assert.is_true(ok, tostring(err))
+    end)
+
+    it("registers via get_parser_configs() (nvim-treesitter v0.x)", function()
+        local cfgs = {}
+        package.loaded["nvim-treesitter.parsers"] = {
+            get_parser_configs = function() return cfgs end,
+        }
+        require("tree-sitter-ghostty").register_parser()
+        assert.is_table(cfgs.ghostty)
+        assert.is_table(cfgs.ghostty.install_info)
+        assert.are.same({ "src/parser.c" }, cfgs.ghostty.install_info.files)
+        assert.is_true(cfgs.ghostty.requires_generate_from_grammar)
+    end)
+
+    it("registers via the parsers table directly (nvim-treesitter v1.x)", function()
+        local fake = {}
+        package.loaded["nvim-treesitter.parsers"] = fake
+        require("tree-sitter-ghostty").register_parser()
+        assert.is_table(fake.ghostty)
+        assert.is_table(fake.ghostty.install_info)
+    end)
+
+    it("does not overwrite an existing ghostty registration", function()
+        local existing = {
+            install_info = { url = "elsewhere", files = {}, branch = "x" },
+        }
+        local cfgs = { ghostty = existing }
+        package.loaded["nvim-treesitter.parsers"] = {
+            get_parser_configs = function() return cfgs end,
+        }
+        require("tree-sitter-ghostty").register_parser()
+        assert.are.equal(existing, cfgs.ghostty)
+    end)
+end)


### PR DESCRIPTION
## Summary
- Adds a [plenary.nvim] busted-style test suite under `tests/nvim/` covering filetype detection, ftplugin behavior, `register_parser()` across nvim-treesitter v0.x and v1.x, and `:checkhealth tree-sitter-ghostty` output (including the tree-sitter-cli version warning).
- New `nvim_test` Make target builds the parser and runs the suite headlessly via `PlenaryBustedDirectory`; plenary signals failures with `cquit` so CI fails loudly.
- New `nvim-test` job in `.github/workflows/ci.yml` installs Neovim stable, clones plenary into `.deps/`, builds the parser, and runs the suite on every push/PR. Path filters expanded to include `lua/`, `tests/`, `plugin/`, `ftdetect/`, `ftplugin/`, `Makefile`, and the workflow file itself.
- READMEs added under `test/` and `tests/` to distinguish grammar tests (run by `tree-sitter test`) from Neovim plugin tests (run by `make nvim_test`).

## Test plan
- [x] `make nvim_test` passes locally (17/17 specs, exit 0)
- [x] Verified plenary exits non-zero when a spec fails
- [x] `tree-sitter test` still scans only `test/corpus/` — `tests/` is invisible to the grammar test action
- [x] CI green on this PR

[plenary.nvim]: https://github.com/nvim-lua/plenary.nvim

🤖 Generated with [Claude Code](https://claude.com/claude-code)