### PR TITLE
fix(ci): fix failing Windows parser test (node-gyp / VS18)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,12 @@ on:
       - ftdetect/**
       - ftplugin/**
       - Makefile
+      - package.json
+      - package-lock.json
+      - Package.swift
+      - Cargo.*
+      - go.mod
+      - pyproject.toml
       - .github/workflows/ci.yml
   pull_request:
     paths:
@@ -33,6 +39,12 @@ on:
       - ftdetect/**
       - ftplugin/**
       - Makefile
+      - package.json
+      - package-lock.json
+      - Package.swift
+      - Cargo.*
+      - go.mod
+      - pyproject.toml
       - .github/workflows/ci.yml
 
 concurrency:

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,11 +11,11 @@
       "license": "MIT",
       "dependencies": {
         "node-addon-api": "^8.1.0",
-        "node-gyp-build": "^4.8.2",
-        "tree-sitter-cli": "^0.24.3"
+        "node-gyp-build": "^4.8.2"
       },
       "devDependencies": {
-        "prebuildify": "^6.0.1"
+        "prebuildify": "^6.0.1",
+        "tree-sitter-cli": "^0.24.3"
       },
       "peerDependencies": {
         "tree-sitter": "^0.21.1"
@@ -317,6 +317,7 @@
       "version": "0.24.3",
       "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.24.3.tgz",
       "integrity": "sha512-5vS0SiJf31tMTn9CYLsu5l18qXaw5MLFka3cuGxOB5f4TtgoUSK1Sog6rKmqBc7PvFJq37YcQBjj9giNy2cJPw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
   ],
   "dependencies": {
     "node-addon-api": "^8.1.0",
-    "node-gyp-build": "^4.8.2",
-    "tree-sitter-cli": "^0.24.3"
+    "node-gyp-build": "^4.8.2"
   },
   "devDependencies": {
-    "prebuildify": "^6.0.1"
+    "prebuildify": "^6.0.1",
+    "tree-sitter-cli": "^0.24.3"
   },
   "peerDependencies": {
     "tree-sitter": "^0.21.1"


### PR DESCRIPTION
## Problem

The `Test parser (windows-latest)` CI job has been failing since ~May 7 (with no code change), while Linux, macOS, and the Neovim job pass.

The failure is a `node-gyp` build error:

```
gyp ERR! find VS Could not find any Visual Studio installation to use
gyp ERR! find VS unknown version "undefined" found at "...Visual Studio\18\Enterprise"
gyp ERR! find VS Failure details: RangeError [ERR_CHILD_PROCESS_STDIO_MAXBUFFER]
```

The `windows-latest` runner image now ships **Visual Studio 18**, which the bundled `node-gyp` 11.5.0 cannot parse (it overflows its PowerShell stdio buffer and reports no usable VS). Linux/macOS have working toolchains, so they're unaffected.

## Root cause

`tree-sitter/parser-test-action`'s "Verify generated parser" step gates `npm ci` on:

```
.dependencies | del("node-addon-api", "node-gyp-build") | length > 0
```

Because `tree-sitter-cli` was a runtime **dependency**, the gate passed, `npm ci` ran the package's `install` script (`node-gyp-build`), and the native Node binding compile failed on Windows. The parser tests use the `tree-sitter` binary from `setup-action`, and the Go binding test uses `go` — so this native compile was never actually needed in CI.

## Fix

Move `tree-sitter-cli` from `dependencies` to `devDependencies` (it's a build tool, not a runtime dependency). The gate now evaluates to `false`, so `npm ci` and the doomed node-gyp build are skipped on all platforms, while `npm start` / `npm run prebuildify` still work locally via the dev `.bin`. `package-lock.json` regenerated to match and verified in-sync with `npm ci --dry-run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)