### PR TITLE
fix(nvim): use proper nvim-treesitter API to self-register as a parser

### DIFF
--- a/lua/tree-sitter-ghostty/init.lua
+++ b/lua/tree-sitter-ghostty/init.lua
@@ -1,39 +1,21 @@
 local M = {}
 
 M.register_parser = function()
-    local ok, parsers = pcall(require, "nvim-treesitter.parsers")
-    if not ok then
-        return
-    end
-
-    -- Register the plugin path as a tree-sitter parser to nvim-treesitter.
-    -- This is not required, but it allows nvim-treesitter to manage it e.g. :TS{Install,Update} ghostty
     local file = debug.getinfo(1).source:match("@(.*/)")
     local plugin_dir = vim.fn.fnamemodify(file, ":p:h:h:h")
 
-    --- @type ParserInfo[]
-    local parser_configs
-
-    if type(parsers.get_parser_configs) == "function" then
-        parser_configs = parsers.get_parser_configs()
-    else
-        -- "nvim-treesitter.parsers" exports the parser table itself starting nvim-treesitter v1.x
-        parser_configs = parsers
-    end
-
-    if type(parser_configs.ghostty) == "table" then
-        -- A ghostty parser is already registered. Avoid overwriting it.
-        return
-    end
-
-    parser_configs.ghostty = {
-        install_info = {
-            url = plugin_dir,
-            files = { "src/parser.c" },
-            branch = "main",
-        },
-        requires_generate_from_grammar = true,
-    }
+    vim.api.nvim_create_autocmd('User', {
+        pattern = 'TSUpdate',
+        callback = function()
+            ---@diagnostic disable: missing-fields
+            require('nvim-treesitter.parsers').ghostty = {
+                install_info = {
+                    path = plugin_dir,
+                    generate = true
+                },
+            }
+        end
+    })
 end
 
 return M

--- a/tests/nvim/parser_registration_spec.lua
+++ b/tests/nvim/parser_registration_spec.lua
@@ -16,36 +16,4 @@ describe("tree-sitter-ghostty.register_parser", function()
         end)
         assert.is_true(ok, tostring(err))
     end)
-
-    it("registers via get_parser_configs() (nvim-treesitter v0.x)", function()
-        local cfgs = {}
-        package.loaded["nvim-treesitter.parsers"] = {
-            get_parser_configs = function() return cfgs end,
-        }
-        require("tree-sitter-ghostty").register_parser()
-        assert.is_table(cfgs.ghostty)
-        assert.is_table(cfgs.ghostty.install_info)
-        assert.are.same({ "src/parser.c" }, cfgs.ghostty.install_info.files)
-        assert.is_true(cfgs.ghostty.requires_generate_from_grammar)
-    end)
-
-    it("registers via the parsers table directly (nvim-treesitter v1.x)", function()
-        local fake = {}
-        package.loaded["nvim-treesitter.parsers"] = fake
-        require("tree-sitter-ghostty").register_parser()
-        assert.is_table(fake.ghostty)
-        assert.is_table(fake.ghostty.install_info)
-    end)
-
-    it("does not overwrite an existing ghostty registration", function()
-        local existing = {
-            install_info = { url = "elsewhere", files = {}, branch = "x" },
-        }
-        local cfgs = { ghostty = existing }
-        package.loaded["nvim-treesitter.parsers"] = {
-            get_parser_configs = function() return cfgs end,
-        }
-        require("tree-sitter-ghostty").register_parser()
-        assert.are.equal(existing, cfgs.ghostty)
-    end)
 end)


### PR DESCRIPTION
I suspect https://github.com/bezhermoso/tree-sitter-ghostty/issues/40 is because the user is on `nvim-treesitter`'s `main` branch. I just ran into a similar problem. This should fix that.