### PR TITLE
Align queries with Neovim treesitter conventions and validate them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ on:
       - Cargo.*
       - go.mod
       - pyproject.toml
+      - .tsqueryrc.json
       - .github/workflows/ci.yml
   pull_request:
     paths:
@@ -45,6 +46,7 @@ on:
       - Cargo.*
       - go.mod
       - pyproject.toml
+      - .tsqueryrc.json
       - .github/workflows/ci.yml
 
 concurrency:
@@ -75,6 +77,21 @@ jobs:
           test-rust: ${{runner.os == 'Linux'}}
           test-go: ${{runner.os == 'Windows'}}
           test-swift: ${{runner.os == 'macOS'}}
+
+  query:
+    name: Validate queries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up tree-sitter
+        uses: tree-sitter/setup-action/cli@v2
+      - name: Build parser
+        run: tree-sitter build
+      - name: Set up ts_query_ls
+        run: curl -fL https://github.com/ribru17/ts_query_ls/releases/latest/download/ts_query_ls-x86_64-unknown-linux-gnu.tar.gz | tar -xz
+      - name: Check queries
+        run: ./ts_query_ls check -f queries/
 
   nvim-test:
     name: Test Neovim plugin

--- a/.tsqueryrc.json
+++ b/.tsqueryrc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ribru17/ts_query_ls/refs/heads/master/schemas/config.json",
+  "parser_install_directories": ["."]
+}

--- a/queries/ghostty/highlights.scm
+++ b/queries/ghostty/highlights.scm
@@ -1,4 +1,5 @@
 ; extends
+
 ; Comments
 (comment) @comment
 
@@ -9,69 +10,80 @@
 (boolean) @boolean
 
 [
- (string)
- (color)
+  (string)
+  (color)
 ] @string
 
 [
- (number)
- (adjustment)
+  (number)
+  (adjustment)
 ] @number
 
 ; (color) are hex values
-(color "#" @punctuation.delimiter.special
-  (#eq? @punctuation.delimiter.special "#"))
+(color
+  "#" @punctuation.special
+  (#eq? @punctuation.special "#"))
 
 ; (tuple)
-(tuple "," @punctuation.delimiter.special
-       (#eq? @punctuation.delimiter.special ","))
+(tuple
+  "," @punctuation.delimiter
+  (#eq? @punctuation.delimiter ","))
 
 ; `palette`
 (palette_index) @variable.member
 
-(palette_value "=" @operator
+(palette_value
+  "=" @operator
   (#eq? @operator "="))
 
 ; env
 (env_var_name) @variable.member
-(env_value "=" @operator
-           (#eq? @operator "="))
+
+(env_value
+  "=" @operator
+  (#eq? @operator "="))
 
 ; `path directives`
-(path_directive (property) @keyword.import)
-(path_directive (path_value) @string.special.path)
-(path_value "?" @keyword.conditional
-    (#eq? @keyword.conditional "?"))
+(path_directive
+  (property) @keyword.import)
+
+(path_directive
+  (path_value) @string.special.path)
+
+(path_value
+  "?" @keyword.conditional
+  (#eq? @keyword.conditional "?"))
 
 ; `keybind`
 (keybind_value) @string.special
 
 ; clear is a special keyword that clear all existing keybind up to that point
 ((keybind_value) @keyword
-                 (#eq? @keyword "clear"))
+  (#eq? @keyword "clear"))
 
 (keybind_action) @function.call
+
 (action_argument) @variable.parameter
 
 [
- "+"
- "="
- (keybind_trigger ">")
- (chain_operator)
+  "+"
+  "="
+  (keybind_trigger
+    ">")
+  (chain_operator)
 ] @operator
 
 ; NOTE: The order here matters!
 [
- (modifier_key)
- (key)
+  (modifier_key)
+  (key)
 ] @constant.builtin
 
 [
- (key_qualifier)
- (keybind_modifier)
- (theme_variant)
- (command_modifier)
+  (key_qualifier)
+  (keybind_modifier)
+  (theme_variant)
+  (command_modifier)
 ] @attribute
 
 (keybind_table) @module
-


### PR DESCRIPTION
Brings the bundled queries in line with Neovim treesitter conventions and standards, and keeps them that way via CI.

- `highlights.scm`: replaces the non-standard `@punctuation.delimiter.special` capture with the standard `@punctuation.special` (hex color prefix) and `@punctuation.delimiter` (tuple separator), and reformats the file with `ts_query_ls format`.
- Adds a **Validate queries** CI job that builds the parser and runs `ts_query_ls check -f queries/`, with a minimal `.tsqueryrc.json` pointing it at the built parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)