### PR TITLE
Attach release artifacts (tarball + WASM) on tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+name: Publish package
+
+on:
+  push:
+    tags: ["*"]
+
+concurrency:
+  group: ${{github.workflow}}-${{github.ref}}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
+jobs:
+  release:
+    uses: tree-sitter/workflows/.github/workflows/release.yml@main
+    with:
+      generate: true
+
+  # NOTE: uncomment the packages you want to publish
+
+  # npm:
+  #   uses: tree-sitter/workflows/.github/workflows/package-npm.yml@main
+  #   secrets:
+  #     NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+
+  # crates:
+  #   uses: tree-sitter/workflows/.github/workflows/package-crates.yml@main
+  #   secrets:
+  #     CARGO_REGISTRY_TOKEN: ${{secrets.CARGO_TOKEN}}
+
+  # pypi:
+  #   uses: tree-sitter/workflows/.github/workflows/package-pypi.yml@main
+  #   secrets:
+  #     PYPI_API_TOKEN: ${{secrets.PYPI_TOKEN}}


### PR DESCRIPTION
Adds the standard tree-sitter publish workflow (`tree-sitter/workflows` reusable release workflow). On the next tag push, the GitHub release will automatically get a source tarball and a WASM build attached.

Package registry jobs (npm, crates, PyPI) are included but commented out; they can be enabled later once the corresponding tokens are configured.

No release is cut by this PR — the workflow only runs on tag push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)